### PR TITLE
Update ingress URL

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,6 +1,6 @@
 generic-service:
   ingress:
-    host: hmpps-sentence-plan-dev.hmpps.service.justice.gov.uk
+    host: sentence-plan-api-dev.hmpps.service.justice.gov.uk
 
   env:
     SENTRY_ENVIRONMENT: dev


### PR DESCRIPTION
Removed `hmpps` prefix as it's already in the subdomain, and added the `api` qualifier.

Certs have been updated in this PR: https://github.com/ministryofjustice/cloud-platform-environments/pull/12511