### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.1.0
+  hmpps: ministryofjustice/hmpps@7
   gradle: circleci/gradle@3.0.0
   mem: circleci/rememborb@0.0.2
 
@@ -112,7 +112,7 @@ workflows:
       - hmpps/trivy_latest_scan:
           name: vulnerability_scan
           slack_channel: probation-integration-notifications
-          requires: [jib-build]
+          requires: [ jib-build ]
           context:
             - hmpps-common-vars
           filters:

--- a/helm_deploy/hmpps-sentence-plan/Chart.yaml
+++ b/helm_deploy/hmpps-sentence-plan/Chart.yaml
@@ -6,7 +6,7 @@ version: 1.0.0
 
 dependencies:
   - name: generic-service
-    version: 2.5.0
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.0


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

0 allowlist(s) have been detected that can be migrated.


