### PR TITLE
SP2-457 Refactor backend naming schema references from 'id' to 'uuid' where appropriate

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/GoalController.kt
@@ -26,13 +26,13 @@ class GoalController(private val service: GoalService) {
     return service.createNewGoal(goal)
   }
 
-  @PostMapping("/{goalId}/steps")
+  @PostMapping("/{goalUuid}/steps")
   @ResponseStatus(HttpStatus.CREATED)
   fun createNewStep(
-    @PathVariable goalId: UUID,
+    @PathVariable goalUuid: UUID,
     @RequestBody steps: List<StepEntity>,
   ): List<StepEntity> {
-    return service.createNewStep(steps, goalId)
+    return service.createNewStep(steps, goalUuid)
   }
 
   @GetMapping
@@ -41,12 +41,12 @@ class GoalController(private val service: GoalService) {
     return service.getAllGoals()
   }
 
-  @GetMapping("/{goalId}/steps")
+  @GetMapping("/{goalUuid}/steps")
   @ResponseStatus(HttpStatus.OK)
   fun getAllGoalSteps(
-    @PathVariable goalId: UUID,
+    @PathVariable goalUuid: UUID,
   ): List<StepEntity> {
-    return service.getAllGoalSteps(goalId)
+    return service.getAllGoalSteps(goalUuid)
   }
 
   @PostMapping("/order")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/data/GoalOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/data/GoalOrder.kt
@@ -4,6 +4,6 @@ import com.google.gson.annotations.SerializedName
 import java.util.UUID
 
 data class GoalOrder(
-  @SerializedName("goalId") var goalId: UUID,
+  @SerializedName("goalUuid") var goalUuid: UUID,
   @SerializedName("galOrder") var goalOrder: Int? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/GoalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/GoalEntity.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.entity
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
@@ -20,6 +21,7 @@ class GoalEntity(
   @Id
   @Column(name = "id")
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @JsonIgnore
   val id: Long? = null,
 
   @Column(name = "uuid")
@@ -45,7 +47,7 @@ class GoalEntity(
 )
 
 interface GoalRepository : JpaRepository<GoalEntity, UUID> {
-  override fun findById(uuid: UUID): Optional<GoalEntity>
+  fun findByUuid(uuid: UUID): Optional<GoalEntity>
 
   @Modifying
   @Query("update Goal g set g.goalOrder = ?1 where g.uuid = ?2")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/GoalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/GoalEntity.kt
@@ -46,7 +46,7 @@ class GoalEntity(
   val planUuid: UUID,
 )
 
-interface GoalRepository : JpaRepository<GoalEntity, UUID> {
+interface GoalRepository : JpaRepository<GoalEntity, Long> {
   fun findByUuid(uuid: UUID): Optional<GoalEntity>
 
   @Modifying

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanEntity.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.entity
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.persistence.AttributeConverter
 import jakarta.persistence.Column
 import jakarta.persistence.Converter
@@ -11,7 +12,7 @@ import jakarta.persistence.Table
 import org.springframework.data.jpa.repository.JpaRepository
 import java.time.Instant
 import java.time.format.DateTimeFormatter
-import java.util.UUID
+import java.util.*
 
 @Entity(name = "Plan")
 @Table(name = "plan")
@@ -19,6 +20,7 @@ class PlanEntity(
   @Id
   @Column(name = "id")
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @JsonIgnore
   val id: Long? = null,
 
   @Column(name = "uuid")
@@ -48,4 +50,6 @@ class PlanStatusConverter : AttributeConverter<PlanStatus, String> {
   override fun convertToEntityAttribute(status: String): PlanStatus = PlanStatus.valueOf(status.uppercase())
 }
 
-interface PlanRepository : JpaRepository<PlanEntity, Long>
+interface PlanRepository : JpaRepository<PlanEntity, Long> {
+  fun findByUuid(uuid: UUID): Optional<PlanEntity>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/StepEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/StepEntity.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.entity
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
@@ -18,13 +19,14 @@ class StepEntity(
   @Id
   @Column(name = "id")
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @JsonIgnore
   val id: Long? = null,
 
   @Column(name = "uuid")
   val uuid: UUID = UUID.randomUUID(),
 
-  @Column(name = "related_goal_id")
-  var relatedGoalId: UUID? = null,
+  @Column(name = "related_goal_uuid")
+  var relatedGoalUuid: UUID? = null,
 
   @Column(name = "description")
   val description: String,
@@ -40,7 +42,7 @@ class StepEntity(
 
 )
 
-interface StepRepository : JpaRepository<StepEntity, UUID> {
-  override fun findById(uuid: UUID): Optional<StepEntity>
-  fun findAllByRelatedGoalId(relatedGoalId: UUID): Optional<List<StepEntity>>
+interface StepRepository : JpaRepository<StepEntity, Long> {
+  fun findByUuid(uuid: UUID): Optional<StepEntity>
+  fun findAllByRelatedGoalUuid(relatedGoalUuid: UUID): Optional<List<StepEntity>>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
@@ -15,30 +15,24 @@ class GoalService(
   private val stepRepository: StepRepository,
 ) {
 
-  fun createNewGoal(goal: GoalEntity): GoalEntity {
-    return goalRepository.save(goal)
-  }
+  fun createNewGoal(goal: GoalEntity): GoalEntity = goalRepository.save(goal)
 
   @Transactional
-  fun createNewStep(steps: List<StepEntity>, goalId: UUID): List<StepEntity> {
+  fun createNewStep(steps: List<StepEntity>, goalUuid: UUID): List<StepEntity> {
     for (step in steps) {
-      step.relatedGoalId = goalId
+      step.relatedGoalId = goalUuid
     }
     return stepRepository.saveAll(steps)
   }
 
-  fun getAllGoals(): List<GoalEntity> {
-    return goalRepository.findAll()
-  }
+  fun getAllGoals(): List<GoalEntity> = goalRepository.findAll()
 
-  fun getAllGoalSteps(goalId: UUID): List<StepEntity> {
-    return stepRepository.findAllByRelatedGoalId(goalId).get()
-  }
+  fun getAllGoalSteps(goalUuid: UUID): List<StepEntity> = stepRepository.findAllByRelatedGoalId(goalUuid).get()
 
   @Transactional
   fun updateGoalsOrder(goalsOrder: List<GoalOrder>) {
     for (goal in goalsOrder) {
-      goal.goalOrder?.let { goalRepository.updateGoalOrder(it, goal.goalId) }
+      goal.goalOrder?.let { goalRepository.updateGoalOrder(it, goal.goalUuid) }
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
@@ -20,14 +20,14 @@ class GoalService(
   @Transactional
   fun createNewStep(steps: List<StepEntity>, goalUuid: UUID): List<StepEntity> {
     for (step in steps) {
-      step.relatedGoalId = goalUuid
+      step.relatedGoalUuid = goalUuid
     }
     return stepRepository.saveAll(steps)
   }
 
   fun getAllGoals(): List<GoalEntity> = goalRepository.findAll()
 
-  fun getAllGoalSteps(goalUuid: UUID): List<StepEntity> = stepRepository.findAllByRelatedGoalId(goalUuid).get()
+  fun getAllGoalSteps(goalUuid: UUID): List<StepEntity> = stepRepository.findAllByRelatedGoalUuid(goalUuid).get()
 
   @Transactional
   fun updateGoalsOrder(goalsOrder: List<GoalOrder>) {

--- a/src/main/resources/db/migration/V1__goal.sql
+++ b/src/main/resources/db/migration/V1__goal.sql
@@ -12,12 +12,12 @@ create table if not exists goal
 
 create table if not exists step
 (
-    id                  serial          PRIMARY KEY,
-    uuid                uuid            NOT NULL UNIQUE,
-    related_goal_id     uuid            NOT NULL,
-    description         varchar(256)    NOT NULL,
-    actor               varchar(256)    NOT NULL,
-    status              varchar(256)    NOT NULL,
-    creation_date       timestamp       NOT NULL,
-    FOREIGN KEY (related_goal_id) REFERENCES goal (uuid)
+    id                    serial          PRIMARY KEY,
+    uuid                  uuid            NOT NULL UNIQUE,
+    related_goal_uuid     uuid            NOT NULL,
+    description           varchar(256)    NOT NULL,
+    actor                 varchar(256)    NOT NULL,
+    status                varchar(256)    NOT NULL,
+    creation_date         timestamp       NOT NULL,
+    FOREIGN KEY (related_goal_uuid) REFERENCES goal (uuid)
 );

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
@@ -22,10 +22,9 @@ class GoalControllerTest : IntegrationTestBase() {
   lateinit var planRepository: PlanRepository
 
   var goalRequestBody: GoalEntity? = null
-  var goalEntity: GoalEntity? = null
 
   private val goalOrder = GoalOrder(
-    goalId = UUID.randomUUID(),
+    goalUuid = UUID.randomUUID(),
     goalOrder = 1,
   )
 
@@ -41,15 +40,6 @@ class GoalControllerTest : IntegrationTestBase() {
       title = "abc",
       areaOfNeed = "xzv",
       creationDate = currentTime,
-      targetDate = currentTime,
-      goalOrder = 1,
-      planUuid = plan.uuid,
-    )
-
-    goalEntity = GoalEntity(
-      id = 123L,
-      title = "title",
-      areaOfNeed = "area",
       targetDate = currentTime,
       goalOrder = 1,
       planUuid = plan.uuid,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
@@ -34,7 +34,7 @@ class GoalServiceTest {
   val stepEntity = StepEntity(
     description = "description",
     id = 123L,
-    relatedGoalId = uuid,
+    relatedGoalUuid = uuid,
     actor = "actor",
     status = "status",
     creationDate = currentTime,
@@ -56,7 +56,7 @@ class GoalServiceTest {
     val stepsList = goalService.createNewStep(listOf(stepEntity), uuid)
     assertThat(stepsList.get(0).status).isEqualTo("status")
     assertThat(stepsList.get(0).id).isEqualTo(123)
-    assertThat(stepsList.get(0).relatedGoalId).isEqualTo(uuid)
+    assertThat(stepsList.get(0).relatedGoalUuid).isEqualTo(uuid)
     assertThat(stepsList.get(0).actor).isEqualTo("actor")
     assertThat(stepsList.get(0).description).isEqualTo("description")
     assertThat(stepsList.get(0).creationDate).isEqualTo(currentTime)
@@ -72,7 +72,7 @@ class GoalServiceTest {
 
   @Test
   fun `get all goal steps`() {
-    every { stepRepository.findAllByRelatedGoalId(uuid) } returns Optional.of(listOf(stepEntity))
+    every { stepRepository.findAllByRelatedGoalUuid(uuid) } returns Optional.of(listOf(stepEntity))
     val stepList = goalService.getAllGoalSteps(uuid)
     assertThat(stepList.size).isEqualTo(1)
     assertThat(stepList[0]).isEqualTo(stepEntity)


### PR DESCRIPTION
Renames object, repository and service references to match the field they are using, as well as a foreign key in the migration scripts.

Also adds `@JsonIgnore` to the ID fields of Plan, Goal and Step so they are ignored during API serialisation/deserialisation. 