### PR TITLE
SP2 438 - Add new endpoints for getting Plan by UUID and OASys Assessment PK

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/config/HmppsSentencePlanExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/config/HmppsSentencePlanExceptionHandler.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.sentenceplan.config
 
 import jakarta.validation.ValidationException
 import org.slf4j.LoggerFactory
-import org.springframework.dao.EmptyResultDataAccessException
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
@@ -24,17 +23,6 @@ class HmppsSentencePlanExceptionHandler {
         developerMessage = e.message,
       ),
     ).also { log.info("Validation exception: {}", e.message) }
-
-  @ExceptionHandler(EmptyResultDataAccessException::class)
-  fun handleEmptyResultDataAccessException(e: EmptyResultDataAccessException): ResponseEntity<ErrorResponse> = ResponseEntity
-    .status(NOT_FOUND)
-    .body(
-      ErrorResponse(
-        status = NOT_FOUND,
-        userMessage = "No object of that type was found: ${e.message}",
-        developerMessage = e.message,
-      ),
-    ).also { log.info("Database query return 0 results : {}", e.message) }
 
   @ExceptionHandler(NoResourceFoundException::class)
   fun handleNoResourceFoundException(e: NoResourceFoundException): ResponseEntity<ErrorResponse> = ResponseEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/config/HmppsSentencePlanExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/config/HmppsSentencePlanExceptionHandler.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.sentenceplan.config
 
 import jakarta.validation.ValidationException
 import org.slf4j.LoggerFactory
+import org.springframework.dao.EmptyResultDataAccessException
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
@@ -23,6 +24,17 @@ class HmppsSentencePlanExceptionHandler {
         developerMessage = e.message,
       ),
     ).also { log.info("Validation exception: {}", e.message) }
+
+  @ExceptionHandler(EmptyResultDataAccessException::class)
+  fun handleEmptyResultDataAccessException(e: EmptyResultDataAccessException): ResponseEntity<ErrorResponse> = ResponseEntity
+    .status(NOT_FOUND)
+    .body(
+      ErrorResponse(
+        status = NOT_FOUND,
+        userMessage = "No object of that type was found: ${e.message}",
+        developerMessage = e.message,
+      ),
+    ).also { log.info("Database query return 0 results : {}", e.message) }
 
   @ExceptionHandler(NoResourceFoundException::class)
   fun handleNoResourceFoundException(e: NoResourceFoundException): ResponseEntity<ErrorResponse> = ResponseEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/OasysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/OasysController.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.sentenceplan.controlller
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
+import uk.gov.justice.digital.hmpps.sentenceplan.services.PlanService
+import java.util.*
+
+@RestController
+@RequestMapping("/oasys")
+class OasysController(private val service: PlanService) {
+
+  @GetMapping("/{oasysAssessmentPk}")
+  fun getPlan(
+    @PathVariable oasysAssessmentPk: String,
+  ): PlanEntity {
+    return service.getPlanByOasysAssessmentPk(oasysAssessmentPk)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/OasysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/OasysController.kt
@@ -1,14 +1,13 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.controlller
 
-import org.springframework.dao.EmptyResultDataAccessException
+import org.springframework.http.HttpMethod
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.resource.NoResourceFoundException
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.services.PlanService
-
-private const val EXPECTED_RESULT_COUNT = 1
 
 @RestController
 @RequestMapping("/oasys")
@@ -18,6 +17,6 @@ class OasysController(private val service: PlanService) {
   fun getPlan(
     @PathVariable oasysAssessmentPk: String,
   ): PlanEntity {
-    return service.getPlanByOasysAssessmentPk(oasysAssessmentPk) ?: throw EmptyResultDataAccessException(EXPECTED_RESULT_COUNT)
+    return service.getPlanByOasysAssessmentPk(oasysAssessmentPk) ?: throw NoResourceFoundException(HttpMethod.GET, "No resource found for $oasysAssessmentPk")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/OasysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/OasysController.kt
@@ -1,12 +1,14 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.controlller
 
+import org.springframework.dao.EmptyResultDataAccessException
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.services.PlanService
-import java.util.*
+
+private const val EXPECTED_RESULT_COUNT = 1
 
 @RestController
 @RequestMapping("/oasys")
@@ -16,6 +18,6 @@ class OasysController(private val service: PlanService) {
   fun getPlan(
     @PathVariable oasysAssessmentPk: String,
   ): PlanEntity {
-    return service.getPlanByOasysAssessmentPk(oasysAssessmentPk)
+    return service.getPlanByOasysAssessmentPk(oasysAssessmentPk) ?: throw EmptyResultDataAccessException(EXPECTED_RESULT_COUNT)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/PlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/PlanController.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.sentenceplan.controlller
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
+import uk.gov.justice.digital.hmpps.sentenceplan.services.PlanService
+import java.util.*
+
+@RestController
+@RequestMapping("/plans")
+class PlanController(private val service: PlanService) {
+
+  @GetMapping("/{planUuid}")
+  fun getPlan(
+    @PathVariable planUuid: UUID,
+  ): PlanEntity {
+    return service.getPlanByUuid(planUuid)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/PlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/PlanController.kt
@@ -1,15 +1,14 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.controlller
 
-import org.springframework.dao.EmptyResultDataAccessException
+import org.springframework.http.HttpMethod
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.resource.NoResourceFoundException
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.services.PlanService
 import java.util.*
-
-private const val EXPECTED_RESULT_COUNT = 1
 
 @RestController
 @RequestMapping("/plans")
@@ -19,6 +18,6 @@ class PlanController(private val service: PlanService) {
   fun getPlan(
     @PathVariable planUuid: UUID,
   ): PlanEntity {
-    return service.getPlanByUuid(planUuid) ?: throw EmptyResultDataAccessException(EXPECTED_RESULT_COUNT)
+    return service.getPlanByUuid(planUuid) ?: throw NoResourceFoundException(HttpMethod.GET, "No resource found for $planUuid")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/PlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/PlanController.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.controlller
 
+import org.springframework.dao.EmptyResultDataAccessException
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -7,6 +8,8 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.services.PlanService
 import java.util.*
+
+private const val EXPECTED_RESULT_COUNT = 1
 
 @RestController
 @RequestMapping("/plans")
@@ -16,6 +19,6 @@ class PlanController(private val service: PlanService) {
   fun getPlan(
     @PathVariable planUuid: UUID,
   ): PlanEntity {
-    return service.getPlanByUuid(planUuid)
+    return service.getPlanByUuid(planUuid) ?: throw EmptyResultDataAccessException(EXPECTED_RESULT_COUNT)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanEntity.kt
@@ -53,8 +53,7 @@ class PlanStatusConverter : AttributeConverter<PlanStatus, String> {
 }
 
 interface PlanRepository : JpaRepository<PlanEntity, Long> {
-  @Query("SELECT p FROM Plan p WHERE p.uuid = :uuid")
-  fun findByUuid(@Param("uuid") uuid: UUID): PlanEntity?
+  fun findByUuid(uuid: UUID): PlanEntity?
 
   @Query("select p.* from plan p inner join oasys_pk_to_plan o on p.uuid = o.plan_uuid and o.oasys_assessment_pk = :oasysAssessmentPk", nativeQuery = true)
   fun findByOasysAssessmentPk(@Param("oasysAssessmentPk") oasysAssessmentPk: String): PlanEntity?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanEntity.kt
@@ -10,6 +10,8 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 import java.util.*
@@ -51,5 +53,9 @@ class PlanStatusConverter : AttributeConverter<PlanStatus, String> {
 }
 
 interface PlanRepository : JpaRepository<PlanEntity, Long> {
-  fun findByUuid(uuid: UUID): Optional<PlanEntity>
+  @Query("SELECT p FROM Plan p WHERE p.uuid = :uuid")
+  fun findByUuid(@Param("uuid") uuid: UUID): PlanEntity?
+
+  @Query("select p.* from plan p inner join oasys_pk_to_plan o on p.uuid = o.plan_uuid and o.oasys_assessment_pk = :oasysAssessmentPk", nativeQuery = true)
+  fun findByOasysAssessmentPk(@Param("oasysAssessmentPk") oasysAssessmentPk: String): PlanEntity?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/StepEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/StepEntity.kt
@@ -8,8 +8,6 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 import java.util.Optional
@@ -48,6 +46,5 @@ interface StepRepository : JpaRepository<StepEntity, Long> {
   fun findByUuid(uuid: UUID): Optional<StepEntity>
 
   // This query always returns a list, even if there is no Goal with this UUID
-  @Query("select s from Step s where s.relatedGoalUuid = :relatedGoalUuid")
-  fun findAllByRelatedGoalUuid(@Param("relatedGoalUuid") relatedGoalUuid: UUID): List<StepEntity>
+  fun findByRelatedGoalUuid(relatedGoalUuid: UUID): List<StepEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/StepEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/StepEntity.kt
@@ -8,6 +8,8 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 import java.util.Optional
@@ -44,5 +46,8 @@ class StepEntity(
 
 interface StepRepository : JpaRepository<StepEntity, Long> {
   fun findByUuid(uuid: UUID): Optional<StepEntity>
-  fun findAllByRelatedGoalUuid(relatedGoalUuid: UUID): Optional<List<StepEntity>>
+
+  // This query always returns a list, even if there is no Goal with this UUID
+  @Query("select s from Step s where s.relatedGoalUuid = :relatedGoalUuid")
+  fun findAllByRelatedGoalUuid(@Param("relatedGoalUuid") relatedGoalUuid: UUID): List<StepEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
@@ -27,7 +27,7 @@ class GoalService(
 
   fun getAllGoals(): List<GoalEntity> = goalRepository.findAll()
 
-  fun getAllGoalSteps(goalUuid: UUID): List<StepEntity> = stepRepository.findAllByRelatedGoalUuid(goalUuid)
+  fun getAllGoalSteps(goalUuid: UUID): List<StepEntity> = stepRepository.findByRelatedGoalUuid(goalUuid)
 
   @Transactional
   fun updateGoalsOrder(goalsOrder: List<GoalOrder>) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
@@ -27,7 +27,7 @@ class GoalService(
 
   fun getAllGoals(): List<GoalEntity> = goalRepository.findAll()
 
-  fun getAllGoalSteps(goalUuid: UUID): List<StepEntity> = stepRepository.findAllByRelatedGoalUuid(goalUuid).get()
+  fun getAllGoalSteps(goalUuid: UUID): List<StepEntity> = stepRepository.findAllByRelatedGoalUuid(goalUuid)
 
   @Transactional
   fun updateGoalsOrder(goalsOrder: List<GoalOrder>) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.sentenceplan.services
+
+import org.springframework.dao.EmptyResultDataAccessException
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
+import java.util.*
+
+@Service
+class PlanService(
+  private val planRepository: PlanRepository,
+) {
+
+  fun getPlanByUuid(planUuid: UUID): PlanEntity {
+    return planRepository.findByUuid(planUuid) ?: throw EmptyResultDataAccessException(1)
+  }
+
+  // TODO does this really only expect a single response? should both of these methods be returning a List?
+  fun getPlanByOasysAssessmentPk(oasysAssessmentPk: String): PlanEntity {
+    return planRepository.findByOasysAssessmentPk(oasysAssessmentPk) ?: throw EmptyResultDataAccessException(1)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.services
 
-import org.springframework.dao.EmptyResultDataAccessException
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
@@ -11,12 +10,7 @@ class PlanService(
   private val planRepository: PlanRepository,
 ) {
 
-  fun getPlanByUuid(planUuid: UUID): PlanEntity {
-    return planRepository.findByUuid(planUuid) ?: throw EmptyResultDataAccessException(1)
-  }
+  fun getPlanByUuid(planUuid: UUID): PlanEntity? = planRepository.findByUuid(planUuid)
 
-  // TODO does this really only expect a single response? should both of these methods be returning a List?
-  fun getPlanByOasysAssessmentPk(oasysAssessmentPk: String): PlanEntity {
-    return planRepository.findByOasysAssessmentPk(oasysAssessmentPk) ?: throw EmptyResultDataAccessException(1)
-  }
+  fun getPlanByOasysAssessmentPk(oasysAssessmentPk: String): PlanEntity? = planRepository.findByOasysAssessmentPk(oasysAssessmentPk)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
@@ -6,10 +6,12 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.test.web.reactive.server.expectBodyList
 import uk.gov.justice.digital.hmpps.sentenceplan.data.GoalOrder
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -136,13 +138,13 @@ class GoalControllerTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `get goal steps for UUID which doesn't exist should return not found`() {
+  fun `get goal steps for UUID which doesn't exist should return OK and an empty list`() {
     val randomUuid = UUID.randomUUID()
     webTestClient.get().uri("/goals/$randomUuid/steps")
       .header("Content-Type", "application/json")
       .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .exchange()
-      .expectStatus().isNotFound
+      .expectBodyList<StepEntity>().hasSize(0)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
 import java.time.LocalDateTime
 import java.util.UUID
 
-@AutoConfigureWebTestClient(timeout = "360000000")
+@AutoConfigureWebTestClient(timeout = "5s")
 @DisplayName("Goal Controller Tests")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GoalControllerTest : IntegrationTestBase() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
@@ -136,6 +136,16 @@ class GoalControllerTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `get goal steps for UUID which doesn't exist should return not found`() {
+    val randomUuid = UUID.randomUUID()
+    webTestClient.get().uri("/goals/$randomUuid/steps")
+      .header("Content-Type", "application/json")
+      .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .exchange()
+      .expectStatus().isNotFound
+  }
+
+  @Test
   fun `get goal steps should return unauthorized when no auth token`() {
     webTestClient.get().uri("/goals/e6fb513d-3800-4c35-bb3a-5f9bdc9759dd/steps")
       .header("Content-Type", "application/json")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
@@ -129,12 +129,13 @@ class GoalControllerTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `get goal steps should return OK`() {
-    webTestClient.get().uri("/goals/e6fb513d-3800-4c35-bb3a-5f9bdc9759dd/steps")
+  fun `get goal steps should return OK and contain 1 step`() {
+    webTestClient.get().uri("/goals/31d7e986-4078-4f5c-af1d-115f9ba3722d/steps")
       .header("Content-Type", "application/json")
       .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .exchange()
       .expectStatus().isOk
+      .expectBodyList<StepEntity>().hasSize(1)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/OasysControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/OasysControllerTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
 
-@AutoConfigureWebTestClient(timeout = "360000000")
+@AutoConfigureWebTestClient(timeout = "5s")
 @DisplayName("Oasys Controller Tests")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OasysControllerTest : IntegrationTestBase() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/OasysControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/OasysControllerTest.kt
@@ -1,29 +1,14 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.integration
 
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
-import java.util.*
 
 @AutoConfigureWebTestClient(timeout = "360000000")
 @DisplayName("Oasys Controller Tests")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OasysControllerTest : IntegrationTestBase() {
-
-  @Autowired
-  lateinit var planRepository: PlanRepository
-
-  var plan: PlanEntity? = null
-
-  @BeforeAll
-  fun setup() {
-    // plan = planRepository.findAll().first()
-  }
 
   @Test
   fun `get plan by existing Oasys Assessment PK should return OK`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/OasysControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/OasysControllerTest.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.sentenceplan.integration
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
+import java.util.*
+
+@AutoConfigureWebTestClient(timeout = "360000000")
+@DisplayName("Oasys Controller Tests")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class OasysControllerTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var planRepository: PlanRepository
+
+  var plan: PlanEntity? = null
+
+  @BeforeAll
+  fun setup() {
+    // plan = planRepository.findAll().first()
+  }
+
+  @Test
+  fun `get plan by existing Oasys Assessment PK should return OK`() {
+    val oasysAssessmentPk = "1"
+    webTestClient.get().uri("/oasys/$oasysAssessmentPk")
+      .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .exchange()
+      .expectStatus().isOk
+  }
+
+  @Test
+  fun `get plan by non-existent Oasys Assessment PK should return not found`() {
+    val oasysAssessmentPk = "2"
+    webTestClient.get().uri("/oasys/$oasysAssessmentPk")
+      .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .exchange()
+      .expectStatus().isNotFound
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/PlanControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/PlanControllerTest.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.sentenceplan.integration
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
+import java.util.*
+
+@AutoConfigureWebTestClient(timeout = "360000000")
+@DisplayName("Plan Controller Tests")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PlanControllerTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var planRepository: PlanRepository
+
+  var plan: PlanEntity? = null
+
+  @BeforeAll
+  fun setup() {
+    plan = planRepository.findAll().first()
+  }
+
+  @Test
+  fun `get plan by existing UUID should return OK`() {
+    val planUuid = plan?.uuid
+    webTestClient.get().uri("/plans/$planUuid")
+      .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .exchange()
+      .expectStatus().isOk
+  }
+
+  @Test
+  fun `get plan by non-existent UUID should return not found`() {
+    val planUuid = UUID.randomUUID()
+    webTestClient.get().uri("/plans/$planUuid")
+      .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .exchange()
+      .expectStatus().isNotFound
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/PlanControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/PlanControllerTest.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import java.util.*
 
-@AutoConfigureWebTestClient(timeout = "360000000")
+@AutoConfigureWebTestClient(timeout = "5s")
 @DisplayName("Plan Controller Tests")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PlanControllerTest : IntegrationTestBase() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/PopInfoControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/PopInfoControllerTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
 import uk.gov.justice.digital.hmpps.sentenceplan.data.CRNLinkedRequest
 
-@AutoConfigureWebTestClient(timeout = "360000000")
+@AutoConfigureWebTestClient(timeout = "5s")
 @DisplayName("PopInfo Tests")
 class PopInfoControllerTest : IntegrationTestBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/ReferenceDataControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/ReferenceDataControllerTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
 import uk.gov.justice.digital.hmpps.sentenceplan.data.CRNLinkedRequest
 
-@AutoConfigureWebTestClient(timeout = "360000000")
+@AutoConfigureWebTestClient(timeout = "5s")
 @DisplayName("Reference data Tests")
 class ReferenceDataControllerTest : IntegrationTestBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepRepository
 import java.time.LocalDateTime
-import java.util.Optional
 import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
@@ -72,9 +71,9 @@ class GoalServiceTest {
 
   @Test
   fun `get all goal steps`() {
-    every { stepRepository.findAllByRelatedGoalUuid(uuid) } returns Optional.of(listOf(stepEntity))
+    every { stepRepository.findAllByRelatedGoalUuid(uuid) } returns listOf(stepEntity)
     val stepList = goalService.getAllGoalSteps(uuid)
     assertThat(stepList.size).isEqualTo(1)
-    assertThat(stepList[0]).isEqualTo(stepEntity)
+    assertThat(stepList.get(0)).isEqualTo(stepEntity)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
@@ -71,7 +71,7 @@ class GoalServiceTest {
 
   @Test
   fun `get all goal steps`() {
-    every { stepRepository.findAllByRelatedGoalUuid(uuid) } returns listOf(stepEntity)
+    every { stepRepository.findByRelatedGoalUuid(uuid) } returns listOf(stepEntity)
     val stepList = goalService.getAllGoalSteps(uuid)
     assertThat(stepList.size).isEqualTo(1)
     assertThat(stepList.get(0)).isEqualTo(stepEntity)

--- a/src/test/resources/db/migration/V901__add_oasys_assessment_pk_data.sql
+++ b/src/test/resources/db/migration/V901__add_oasys_assessment_pk_data.sql
@@ -1,0 +1,1 @@
+INSERT INTO oasys_pk_to_plan (id, oasys_assessment_pk, plan_uuid) VALUES (1, '1', '556db5c8-a1eb-4064-986b-0740d6a83c33');

--- a/src/test/resources/db/migration/V902__add_goal_data.sql
+++ b/src/test/resources/db/migration/V902__add_goal_data.sql
@@ -1,0 +1,1 @@
+INSERT INTO goal (uuid, title, area_of_need, target_date, creation_date, goal_order, plan_uuid) VALUES ('31d7e986-4078-4f5c-af1d-115f9ba3722d', 'Goal Title', 'Goal Area of Need', '2024-06-27 16:10:57.299363', '2024-06-27 16:10:57.299363', 1, '556db5c8-a1eb-4064-986b-0740d6a83c33');

--- a/src/test/resources/db/migration/V903__add_step_data.sql
+++ b/src/test/resources/db/migration/V903__add_step_data.sql
@@ -1,0 +1,1 @@
+INSERT INTO step (id, uuid, related_goal_uuid, description, actor, status, creation_date) VALUES (1, '71793b64-545e-4ae7-9936-610639093857', '31d7e986-4078-4f5c-af1d-115f9ba3722d', 'Test step 1', 'Actor name', 'Status name', '2024-06-27 16:26:38.000000');


### PR DESCRIPTION
This PR adds new endpoints for fetching a Plan by its UUID and by the related OASys Assessment PK.

Because we haven't mapped OASys Assessment PK to an object the query is raw SQL.

This PR also includes a change in approach to dealing when an object matching the search criteria can’t be found in the database by adding a new Exception handler in HmppsSentencePlanExceptionHandler so that we can return a 404 when a particular UUID can’t be found. It’s not clear to me if this is the best way of dealing with this, but I think this is better than returning a 500 error which is what happens otherwise.