### PR TITLE
SP2-439 - Refactor /goals endpoints to be prefixed with /plans/{plan-id}

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/GoalController.kt
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.hmpps.sentenceplan.services.GoalService
 import java.util.UUID
 
 @RestController
-@RequestMapping("/goals")
+@RequestMapping("/plans/{planUuid}/goals")
 class GoalController(private val service: GoalService) {
 
   @PostMapping

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/GoalController.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.controlller
 
+import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.resource.NoResourceFoundException
 import uk.gov.justice.digital.hmpps.sentenceplan.data.GoalOrder
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
@@ -15,15 +17,14 @@ import uk.gov.justice.digital.hmpps.sentenceplan.services.GoalService
 import java.util.UUID
 
 @RestController
-@RequestMapping("/plans/{planUuid}/goals")
+@RequestMapping("/goals")
 class GoalController(private val service: GoalService) {
 
-  @PostMapping
-  @ResponseStatus(HttpStatus.CREATED)
-  fun createNewGoal(
-    @RequestBody goal: GoalEntity,
+  @GetMapping("/{goalUuid}")
+  fun getGoal(
+    @PathVariable goalUuid: UUID,
   ): GoalEntity {
-    return service.createNewGoal(goal)
+    return service.getGoalByUuid(goalUuid) ?: throw NoResourceFoundException(HttpMethod.GET, "No goal found for $goalUuid")
   }
 
   @PostMapping("/{goalUuid}/steps")
@@ -33,12 +34,6 @@ class GoalController(private val service: GoalService) {
     @RequestBody steps: List<StepEntity>,
   ): List<StepEntity> {
     return service.createNewStep(goalUuid, steps)
-  }
-
-  @GetMapping
-  @ResponseStatus(HttpStatus.OK)
-  fun getAllGoals(): List<GoalEntity> {
-    return service.getAllGoals()
   }
 
   @GetMapping("/{goalUuid}/steps")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/PlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/PlanController.kt
@@ -12,12 +12,16 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.resource.NoResourceFoundException
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
+import uk.gov.justice.digital.hmpps.sentenceplan.services.GoalService
 import uk.gov.justice.digital.hmpps.sentenceplan.services.PlanService
-import java.util.*
+import java.util.UUID
 
 @RestController
 @RequestMapping("/plans")
-class PlanController(private val service: PlanService) {
+class PlanController(
+  private val service: PlanService,
+  private val goalService: GoalService,
+) {
 
   @GetMapping("/{planUuid}")
   @ResponseStatus(HttpStatus.OK)
@@ -32,7 +36,7 @@ class PlanController(private val service: PlanService) {
   fun getPlanGoals(
     @PathVariable planUuid: UUID,
   ): List<GoalEntity> {
-    return service.getGoalsByPlanUuid(planUuid)
+    return goalService.getGoalsByPlanUuid(planUuid)
   }
 
   @PostMapping("/{planUuid}/goals")
@@ -41,6 +45,6 @@ class PlanController(private val service: PlanService) {
     @PathVariable planUuid: UUID,
     @RequestBody goal: GoalEntity,
   ): GoalEntity {
-    return service.createNewGoal(planUuid, goal)
+    return goalService.createNewGoal(planUuid, goal)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/PlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/PlanController.kt
@@ -1,11 +1,16 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.controlller
 
 import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.resource.NoResourceFoundException
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.services.PlanService
 import java.util.*
@@ -15,9 +20,27 @@ import java.util.*
 class PlanController(private val service: PlanService) {
 
   @GetMapping("/{planUuid}")
+  @ResponseStatus(HttpStatus.OK)
   fun getPlan(
     @PathVariable planUuid: UUID,
   ): PlanEntity {
-    return service.getPlanByUuid(planUuid) ?: throw NoResourceFoundException(HttpMethod.GET, "No resource found for $planUuid")
+    return service.getPlanByUuid(planUuid) ?: throw NoResourceFoundException(HttpMethod.GET, "No Plan found for $planUuid")
+  }
+
+  @GetMapping("/{planUuid}/goals")
+  @ResponseStatus(HttpStatus.OK)
+  fun getPlanGoals(
+    @PathVariable planUuid: UUID,
+  ): List<GoalEntity> {
+    return service.getGoalsByPlanUuid(planUuid)
+  }
+
+  @PostMapping("/{planUuid}/goals")
+  @ResponseStatus(HttpStatus.CREATED)
+  fun createNewGoal(
+    @PathVariable planUuid: UUID,
+    @RequestBody goal: GoalEntity,
+  ): GoalEntity {
+    return service.createNewGoal(planUuid, goal)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/StepController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/StepController.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.sentenceplan.controlller
+
+import org.springframework.http.HttpMethod
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.resource.NoResourceFoundException
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
+import uk.gov.justice.digital.hmpps.sentenceplan.services.StepService
+import java.util.*
+
+@RestController
+@RequestMapping("/steps")
+class StepController(private val service: StepService) {
+
+  @GetMapping("/{stepUuid}")
+  fun getStep(
+    @PathVariable stepUuid: UUID,
+  ): StepEntity {
+    return service.getStepByUuid(stepUuid) ?: throw NoResourceFoundException(HttpMethod.GET, "No step found for $stepUuid")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/GoalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/GoalEntity.kt
@@ -24,7 +24,7 @@ class GoalEntity(
   val id: Long? = null,
 
   @Column(name = "uuid")
-  val uuid: UUID = UUID.randomUUID(),
+  var uuid: UUID = UUID.randomUUID(),
 
   @Column(name = "title")
   val title: String,
@@ -42,11 +42,13 @@ class GoalEntity(
   val goalOrder: Int,
 
   @Column(name = "plan_uuid")
-  val planUuid: UUID,
+  var planUuid: UUID? = null,
 )
 
 interface GoalRepository : JpaRepository<GoalEntity, Long> {
   fun findByUuid(uuid: UUID): GoalEntity?
+
+  fun findByPlanUuid(planUuid: UUID): List<GoalEntity>
 
   @Modifying
   @Query("update Goal g set g.goalOrder = ?1 where g.uuid = ?2")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/StepEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/StepEntity.kt
@@ -10,7 +10,6 @@ import jakarta.persistence.Table
 import org.springframework.data.jpa.repository.JpaRepository
 import java.time.Instant
 import java.time.format.DateTimeFormatter
-import java.util.Optional
 import java.util.UUID
 
 @Entity(name = "Step")
@@ -43,7 +42,7 @@ class StepEntity(
 )
 
 interface StepRepository : JpaRepository<StepEntity, Long> {
-  fun findByUuid(uuid: UUID): Optional<StepEntity>
+  fun findByUuid(uuid: UUID): StepEntity?
 
   // This query always returns a list, even if there is no Goal with this UUID
   fun findByRelatedGoalUuid(relatedGoalUuid: UUID): List<StepEntity>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
@@ -7,7 +7,7 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepRepository
-import java.util.*
+import java.util.UUID
 
 @Service
 class GoalService(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
@@ -17,6 +17,13 @@ class GoalService(
 
   fun getGoalByUuid(goalUuid: UUID): GoalEntity? = goalRepository.findByUuid(goalUuid)
 
+  fun getGoalsByPlanUuid(planUuid: UUID): List<GoalEntity> = goalRepository.findByPlanUuid(planUuid)
+
+  fun createNewGoal(planUuid: UUID, goal: GoalEntity): GoalEntity {
+    goal.planUuid = planUuid
+    return goalRepository.save(goal)
+  }
+
   @Transactional
   fun createNewStep(goalUuid: UUID, steps: List<StepEntity>): List<StepEntity> {
     val stepsRelatedToGoal: List<StepEntity> = addRelatedGoalUuidToSteps(goalUuid, steps)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
@@ -7,7 +7,7 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepRepository
-import java.util.UUID
+import java.util.*
 
 @Service
 class GoalService(
@@ -15,7 +15,7 @@ class GoalService(
   private val stepRepository: StepRepository,
 ) {
 
-  fun createNewGoal(goal: GoalEntity): GoalEntity = goalRepository.save(goal)
+  fun getGoalByUuid(goalUuid: UUID): GoalEntity? = goalRepository.findByUuid(goalUuid)
 
   @Transactional
   fun createNewStep(goalUuid: UUID, steps: List<StepEntity>): List<StepEntity> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.services
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalEntity
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import java.util.*
@@ -8,9 +10,17 @@ import java.util.*
 @Service
 class PlanService(
   private val planRepository: PlanRepository,
+  private val goalRepository: GoalRepository,
 ) {
 
   fun getPlanByUuid(planUuid: UUID): PlanEntity? = planRepository.findByUuid(planUuid)
 
+  fun getGoalsByPlanUuid(planUuid: UUID): List<GoalEntity> = goalRepository.findByPlanUuid(planUuid)
+
   fun getPlanByOasysAssessmentPk(oasysAssessmentPk: String): PlanEntity? = planRepository.findByOasysAssessmentPk(oasysAssessmentPk)
+
+  fun createNewGoal(planUuid: UUID, goal: GoalEntity): GoalEntity {
+    goal.planUuid = planUuid
+    return goalRepository.save(goal)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
@@ -1,26 +1,16 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.services
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalEntity
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
-import java.util.*
+import java.util.UUID
 
 @Service
 class PlanService(
   private val planRepository: PlanRepository,
-  private val goalRepository: GoalRepository,
 ) {
 
   fun getPlanByUuid(planUuid: UUID): PlanEntity? = planRepository.findByUuid(planUuid)
 
-  fun getGoalsByPlanUuid(planUuid: UUID): List<GoalEntity> = goalRepository.findByPlanUuid(planUuid)
-
   fun getPlanByOasysAssessmentPk(oasysAssessmentPk: String): PlanEntity? = planRepository.findByOasysAssessmentPk(oasysAssessmentPk)
-
-  fun createNewGoal(planUuid: UUID, goal: GoalEntity): GoalEntity {
-    goal.planUuid = planUuid
-    return goalRepository.save(goal)
-  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/StepService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/StepService.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.sentenceplan.services
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepRepository
+import java.util.*
+
+@Service
+class StepService(
+  private val stepRepository: StepRepository,
+) {
+
+  fun getStepByUuid(stepUuid: UUID): StepEntity? = stepRepository.findByUuid(stepUuid)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
@@ -34,9 +34,11 @@ class GoalControllerTest : IntegrationTestBase() {
 
   val currentTime = LocalDateTime.now().toString()
 
+  private lateinit var plan: PlanEntity
+
   @BeforeAll
   fun setup() {
-    val plan: PlanEntity = planRepository.findAll().first()
+    plan = planRepository.findAll().first()
 
     goalRequestBody = GoalEntity(
       title = "abc",
@@ -50,7 +52,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
   @Test
   fun `create goal should return created`() {
-    webTestClient.post().uri("/goals").header("Content-Type", "application/json")
+    webTestClient.post().uri("/plans/$plan.uuid/goals").header("Content-Type", "application/json")
       .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .bodyValue(goalRequestBody)
       .exchange()
@@ -59,7 +61,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
   @Test
   fun `create goal should return unauthorized when no auth token`() {
-    webTestClient.post().uri("/goals")
+    webTestClient.post().uri("/plans/$plan.uuid/goals")
       .header("Content-Type", "application/json")
       .bodyValue(goalRequestBody)
       .exchange()
@@ -68,7 +70,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
   @Test
   fun `create goal should return forbidden when no role`() {
-    webTestClient.post().uri("/goals")
+    webTestClient.post().uri("/plans/$plan.uuid/goals")
       .header("Content-Type", "application/json")
       .headers(setAuthorisation(roles = listOf("abc")))
       .bodyValue(goalRequestBody)
@@ -78,7 +80,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
   @Test
   fun `create steps should return unauthorized when no auth token`() {
-    webTestClient.post().uri("/goals/1/steps")
+    webTestClient.post().uri("/plans/$plan.uuid/goals/1/steps")
       .header("Content-Type", "application/json")
       .exchange()
       .expectStatus().isUnauthorized
@@ -86,7 +88,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
   @Test
   fun `create steps should return forbidden when no role`() {
-    webTestClient.post().uri("/goals/1/steps")
+    webTestClient.post().uri("/plans/$plan.uuid/goals/1/steps")
       .header("Content-Type", "application/json")
       .headers(setAuthorisation(roles = listOf("abc")))
       .exchange()
@@ -95,7 +97,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
   @Test
   fun `get goals should return forbidden when no role`() {
-    webTestClient.get().uri("/goals")
+    webTestClient.get().uri("/plans/$plan.uuid/goals")
       .header("Content-Type", "application/json")
       .headers(setAuthorisation(roles = listOf("abc")))
       .exchange()
@@ -104,7 +106,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
   @Test
   fun `get goals should return OK`() {
-    webTestClient.get().uri("/goals")
+    webTestClient.get().uri("/plans/$plan.uuid/goals")
       .header("Content-Type", "application/json")
       .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .exchange()
@@ -113,7 +115,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
   @Test
   fun `get goals should return unauthorized when no auth token`() {
-    webTestClient.get().uri("/goals")
+    webTestClient.get().uri("/plans/$plan.uuid/goals")
       .header("Content-Type", "application/json")
       .exchange()
       .expectStatus().isUnauthorized
@@ -121,7 +123,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
   @Test
   fun `get goal steps should return forbidden when no role`() {
-    webTestClient.get().uri("/goals/e6fb513d-3800-4c35-bb3a-5f9bdc9759dd/steps")
+    webTestClient.get().uri("/plans/$plan.uuid/goals/e6fb513d-3800-4c35-bb3a-5f9bdc9759dd/steps")
       .header("Content-Type", "application/json")
       .headers(setAuthorisation(roles = listOf("abc")))
       .exchange()
@@ -130,7 +132,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
   @Test
   fun `get goal steps should return OK and contain 1 step`() {
-    webTestClient.get().uri("/goals/31d7e986-4078-4f5c-af1d-115f9ba3722d/steps")
+    webTestClient.get().uri("/plans/$plan.uuid/goals/31d7e986-4078-4f5c-af1d-115f9ba3722d/steps")
       .header("Content-Type", "application/json")
       .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .exchange()
@@ -141,7 +143,7 @@ class GoalControllerTest : IntegrationTestBase() {
   @Test
   fun `get goal steps for UUID which doesn't exist should return OK and an empty list`() {
     val randomUuid = UUID.randomUUID()
-    webTestClient.get().uri("/goals/$randomUuid/steps")
+    webTestClient.get().uri("/plans/$plan.uuid/goals/$randomUuid/steps")
       .header("Content-Type", "application/json")
       .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .exchange()
@@ -150,7 +152,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
   @Test
   fun `get goal steps should return unauthorized when no auth token`() {
-    webTestClient.get().uri("/goals/e6fb513d-3800-4c35-bb3a-5f9bdc9759dd/steps")
+    webTestClient.get().uri("/plans/$plan.uuid/goals/e6fb513d-3800-4c35-bb3a-5f9bdc9759dd/steps")
       .header("Content-Type", "application/json")
       .exchange()
       .expectStatus().isUnauthorized
@@ -158,7 +160,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
   @Test
   fun `update goals order should return created`() {
-    webTestClient.post().uri("/goals/order")
+    webTestClient.post().uri("/plans/$plan.uuid/goals/order")
       .header("Content-Type", "application/json")
       .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .bodyValue(goalOrderList)
@@ -168,7 +170,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
   @Test
   fun `update goals order should return unauthorized when no auth token`() {
-    webTestClient.post().uri("/goals/order")
+    webTestClient.post().uri("/plans/$plan.uuid/goals/order")
       .header("Content-Type", "application/json")
       .bodyValue(goalOrderList)
       .exchange()
@@ -177,7 +179,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
   @Test
   fun `update goals order should return forbidden when no role`() {
-    webTestClient.post().uri("/goals/order")
+    webTestClient.post().uri("/plans/$plan.uuid/goals/order")
       .header("Content-Type", "application/json")
       .headers(setAuthorisation(roles = listOf("abc")))
       .bodyValue(goalOrderList)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
@@ -49,15 +49,6 @@ class GoalControllerTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `create goal should return created`() {
-    webTestClient.post().uri("/plans/$plan.uuid/goals").header("Content-Type", "application/json")
-      .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
-      .bodyValue(goalRequestBody)
-      .exchange()
-      .expectStatus().isCreated
-  }
-
-  @Test
   fun `create goal should return unauthorized when no auth token`() {
     webTestClient.post().uri("/plans/$plan.uuid/goals")
       .header("Content-Type", "application/json")
@@ -100,15 +91,6 @@ class GoalControllerTest : IntegrationTestBase() {
       .headers(setAuthorisation(roles = listOf("abc")))
       .exchange()
       .expectStatus().isForbidden
-  }
-
-  @Test
-  fun `get goals should return OK`() {
-    webTestClient.get().uri("/goals")
-      .header("Content-Type", "application/json")
-      .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
-      .exchange()
-      .expectStatus().isOk
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
@@ -43,10 +43,8 @@ class GoalControllerTest : IntegrationTestBase() {
     goalRequestBody = GoalEntity(
       title = "abc",
       areaOfNeed = "xzv",
-      creationDate = currentTime,
       targetDate = currentTime,
       goalOrder = 1,
-      planUuid = plan.uuid,
     )
   }
 
@@ -106,7 +104,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
   @Test
   fun `get goals should return OK`() {
-    webTestClient.get().uri("/plans/$plan.uuid/goals")
+    webTestClient.get().uri("/goals")
       .header("Content-Type", "application/json")
       .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .exchange()
@@ -132,7 +130,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
   @Test
   fun `get goal steps should return OK and contain 1 step`() {
-    webTestClient.get().uri("/plans/$plan.uuid/goals/31d7e986-4078-4f5c-af1d-115f9ba3722d/steps")
+    webTestClient.get().uri("/goals/31d7e986-4078-4f5c-af1d-115f9ba3722d/steps")
       .header("Content-Type", "application/json")
       .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .exchange()
@@ -143,7 +141,7 @@ class GoalControllerTest : IntegrationTestBase() {
   @Test
   fun `get goal steps for UUID which doesn't exist should return OK and an empty list`() {
     val randomUuid = UUID.randomUUID()
-    webTestClient.get().uri("/plans/$plan.uuid/goals/$randomUuid/steps")
+    webTestClient.get().uri("/goals/$randomUuid/steps")
       .header("Content-Type", "application/json")
       .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .exchange()
@@ -160,7 +158,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
   @Test
   fun `update goals order should return created`() {
-    webTestClient.post().uri("/plans/$plan.uuid/goals/order")
+    webTestClient.post().uri("/goals/order")
       .header("Content-Type", "application/json")
       .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .bodyValue(goalOrderList)
@@ -170,7 +168,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
   @Test
   fun `update goals order should return unauthorized when no auth token`() {
-    webTestClient.post().uri("/plans/$plan.uuid/goals/order")
+    webTestClient.post().uri("/goals/order")
       .header("Content-Type", "application/json")
       .bodyValue(goalOrderList)
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/PlanControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/PlanControllerTest.kt
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
+import java.time.LocalDateTime
 import java.util.*
 
 @AutoConfigureWebTestClient(timeout = "5s")
@@ -18,16 +20,24 @@ class PlanControllerTest : IntegrationTestBase() {
   @Autowired
   lateinit var planRepository: PlanRepository
 
-  var plan: PlanEntity? = null
+  var planUuid: UUID? = null
+  var goalRequestBody: GoalEntity? = null
 
   @BeforeAll
   fun setup() {
-    plan = planRepository.findAll().first()
+    val plan: PlanEntity = planRepository.findAll().first()
+    planUuid = plan.uuid
+
+    goalRequestBody = GoalEntity(
+      title = "abc",
+      areaOfNeed = "xzv",
+      targetDate = LocalDateTime.now().toString(),
+      goalOrder = 1,
+    )
   }
 
   @Test
   fun `get plan by existing UUID should return OK`() {
-    val planUuid = plan?.uuid
     webTestClient.get().uri("/plans/$planUuid")
       .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .exchange()
@@ -36,10 +46,28 @@ class PlanControllerTest : IntegrationTestBase() {
 
   @Test
   fun `get plan by non-existent UUID should return not found`() {
-    val planUuid = UUID.randomUUID()
-    webTestClient.get().uri("/plans/$planUuid")
+    val randomPlanUuid = UUID.randomUUID()
+    webTestClient.get().uri("/plans/$randomPlanUuid")
       .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .exchange()
       .expectStatus().isNotFound
+  }
+
+  @Test
+  fun `get goals by plan UUID should return OK`() {
+    webTestClient.get().uri("/plans/$planUuid/goals")
+      .header("Content-Type", "application/json")
+      .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .exchange()
+      .expectStatus().isOk
+  }
+
+  @Test
+  fun `create goal should return created`() {
+    webTestClient.post().uri("/plans/$planUuid/goals").header("Content-Type", "application/json")
+      .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .bodyValue(goalRequestBody)
+      .exchange()
+      .expectStatus().isCreated
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/StepControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/StepControllerTest.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.sentenceplan.integration
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import java.util.UUID
+
+private const val TEST_DATA_STEP_UUID = "71793b64-545e-4ae7-9936-610639093857"
+
+@AutoConfigureWebTestClient(timeout = "5s")
+@DisplayName("Plan Controller Tests")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class StepControllerTest : IntegrationTestBase() {
+
+  @Test
+  fun `get step by existing UUID should return OK`() {
+    webTestClient.get().uri("/steps/${TEST_DATA_STEP_UUID}")
+      .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .exchange()
+      .expectStatus().isOk
+  }
+
+  @Test
+  fun `get step by non-existent UUID should return not found`() {
+    val randomStepUuid = UUID.randomUUID()
+    webTestClient.get().uri("/steps/$randomStepUuid")
+      .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .exchange()
+      .expectStatus().isNotFound
+  }
+}

--- a/src/test/resources/db/migration/V903__add_step_data.sql
+++ b/src/test/resources/db/migration/V903__add_step_data.sql
@@ -1,1 +1,1 @@
-INSERT INTO step (id, uuid, related_goal_uuid, description, actor, status, creation_date) VALUES (1, '71793b64-545e-4ae7-9936-610639093857', '31d7e986-4078-4f5c-af1d-115f9ba3722d', 'Test step 1', 'Actor name', 'Status name', '2024-06-27 16:26:38.000000');
+INSERT INTO step (uuid, related_goal_uuid, description, actor, status, creation_date) VALUES ('71793b64-545e-4ae7-9936-610639093857', '31d7e986-4078-4f5c-af1d-115f9ba3722d', 'Test step 1', 'Actor name', 'Status name', '2024-06-27 16:26:38.000000');


### PR DESCRIPTION
This does as in the title but as it stands the Plan UUID in the URL and submitted in the GoalEntity object can be different - we should enforce one of them to be the main point of reference. I'd suggest we populate the object field from the URL parameter.