### PR TITLE
SP2-470 - Add endpoints and logic for creating plans

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/config/HmppsSentencePlanExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/config/HmppsSentencePlanExceptionHandler.kt
@@ -4,12 +4,14 @@ import jakarta.validation.ValidationException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
+import org.springframework.http.HttpStatus.CONFLICT
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.servlet.resource.NoResourceFoundException
+import uk.gov.justice.digital.hmpps.sentenceplan.exceptions.ConflictException
 
 @RestControllerAdvice
 class HmppsSentencePlanExceptionHandler {
@@ -34,6 +36,17 @@ class HmppsSentencePlanExceptionHandler {
         developerMessage = e.message,
       ),
     ).also { log.info("No resource found exception: {}", e.message) }
+
+  @ExceptionHandler(ConflictException::class)
+  fun handleConflictException(e: ConflictException): ResponseEntity<ErrorResponse> = ResponseEntity
+    .status(CONFLICT)
+    .body(
+      ErrorResponse(
+        status = CONFLICT,
+        userMessage = "Conflicting resource failure: ${e.message}",
+        developerMessage = e.message,
+      ),
+    ).also { log.info("Conflicting resource failure: {}", e.message) }
 
   @ExceptionHandler(Exception::class)
   fun handleException(e: Exception): ResponseEntity<ErrorResponse> = ResponseEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/OasysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/OasysController.kt
@@ -13,7 +13,8 @@ import uk.gov.justice.digital.hmpps.sentenceplan.services.PlanService
 @RequestMapping("/oasys")
 class OasysController(private val service: PlanService) {
 
-  @GetMapping("/{oasysAssessmentPk}")
+  @GetMapping("/plans/{oasysAssessmentPk}")
+  @ResponseStatus(HttpStatus.OK)
   fun getPlan(
     @PathVariable oasysAssessmentPk: String,
   ): PlanEntity {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/OasysController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/OasysController.kt
@@ -1,11 +1,16 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.controlller
 
 import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.resource.NoResourceFoundException
+import uk.gov.justice.digital.hmpps.sentenceplan.data.CreatePlanWithOasysAssesmentPkRequest
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.services.PlanService
 
@@ -19,5 +24,13 @@ class OasysController(private val service: PlanService) {
     @PathVariable oasysAssessmentPk: String,
   ): PlanEntity {
     return service.getPlanByOasysAssessmentPk(oasysAssessmentPk) ?: throw NoResourceFoundException(HttpMethod.GET, "No resource found for $oasysAssessmentPk")
+  }
+
+  @PostMapping("/plans")
+  @ResponseStatus(HttpStatus.CREATED)
+  fun createPlan(
+    @RequestBody requestBody: CreatePlanWithOasysAssesmentPkRequest,
+  ): PlanEntity {
+    return service.createPlanByOasysAssessmentPk(requestBody.oasysAssessmentPk)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/PlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/PlanController.kt
@@ -25,10 +25,8 @@ class PlanController(
 
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
-  fun createPlan(
-    @RequestBody oasysAssessmentPk: String,
-  ): PlanEntity {
-    return service.createPlan(oasysAssessmentPk)
+  fun createPlan(): PlanEntity {
+    return service.createPlan()
   }
 
   @GetMapping("/{planUuid}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/PlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controlller/PlanController.kt
@@ -23,6 +23,14 @@ class PlanController(
   private val goalService: GoalService,
 ) {
 
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  fun createPlan(
+    @RequestBody oasysAssessmentPk: String,
+  ): PlanEntity {
+    return service.createPlan(oasysAssessmentPk)
+  }
+
   @GetMapping("/{planUuid}")
   @ResponseStatus(HttpStatus.OK)
   fun getPlan(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/data/CreatePlanWithOasysAssesmentPkRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/data/CreatePlanWithOasysAssesmentPkRequest.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.sentenceplan.data
+
+data class CreatePlanWithOasysAssesmentPkRequest(
+  val oasysAssessmentPk: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanEntity.kt
@@ -9,7 +9,9 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import jakarta.transaction.Transactional
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.Instant
@@ -52,6 +54,8 @@ interface PlanRepository : JpaRepository<PlanEntity, Long> {
   @Query("select p.* from plan p inner join oasys_pk_to_plan o on p.uuid = o.plan_uuid and o.oasys_assessment_pk = :oasysAssessmentPk", nativeQuery = true)
   fun findByOasysAssessmentPk(@Param("oasysAssessmentPk") oasysAssessmentPk: String): PlanEntity?
 
+  @Modifying
+  @Transactional
   @Query("insert into oasys_pk_to_plan(oasys_assessment_pk, plan_uuid) values (:oasysAssessmentPk, :planUuid)", nativeQuery = true)
-  fun createOasysAssessmentPk(@Param("oasysAssessmentPk") oasysAssessmentPk: String, @Param("planUuid") planUuid: UUID): Long
+  fun createOasysAssessmentPk(@Param("oasysAssessmentPk") oasysAssessmentPk: String, @Param("planUuid") planUuid: UUID)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanEntity.kt
@@ -14,7 +14,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.Instant
 import java.time.format.DateTimeFormatter
-import java.util.*
+import java.util.UUID
 
 @Entity(name = "Plan")
 @Table(name = "plan")
@@ -29,7 +29,7 @@ class PlanEntity(
   val uuid: UUID = UUID.randomUUID(),
 
   @Column(name = "status")
-  val status: PlanStatus,
+  val status: PlanStatus = PlanStatus.INCOMPLETE,
 
   @Column(name = "creation_date")
   val creationDate: String = DateTimeFormatter.ISO_INSTANT.format(Instant.now()),
@@ -57,4 +57,7 @@ interface PlanRepository : JpaRepository<PlanEntity, Long> {
 
   @Query("select p.* from plan p inner join oasys_pk_to_plan o on p.uuid = o.plan_uuid and o.oasys_assessment_pk = :oasysAssessmentPk", nativeQuery = true)
   fun findByOasysAssessmentPk(@Param("oasysAssessmentPk") oasysAssessmentPk: String): PlanEntity?
+
+  @Query("insert into oasys_pk_to_plan(oasys_assessment_pk, plan_uuid) values (:oasysAssessmentPk, :planUuid)", nativeQuery = true)
+  fun createOasysAssessmentPk(@Param("oasysAssessmentPk") oasysAssessmentPk: String, @Param("planUuid") planUuid: UUID): Long
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanEntity.kt
@@ -1,10 +1,10 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.entity
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import jakarta.persistence.AttributeConverter
 import jakarta.persistence.Column
-import jakarta.persistence.Converter
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -29,6 +29,7 @@ class PlanEntity(
   val uuid: UUID = UUID.randomUUID(),
 
   @Column(name = "status")
+  @Enumerated(EnumType.STRING)
   val status: PlanStatus = PlanStatus.INCOMPLETE,
 
   @Column(name = "creation_date")
@@ -43,13 +44,6 @@ enum class PlanStatus {
   COMPLETE,
   LOCKED,
   SIGNED,
-}
-
-@Converter(autoApply = true)
-class PlanStatusConverter : AttributeConverter<PlanStatus, String> {
-  override fun convertToDatabaseColumn(status: PlanStatus): String = status.name
-
-  override fun convertToEntityAttribute(status: String): PlanStatus = PlanStatus.valueOf(status.uppercase())
 }
 
 interface PlanRepository : JpaRepository<PlanEntity, Long> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/exceptions/ConflictException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/exceptions/ConflictException.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.sentenceplan.exceptions
+
+open class ConflictException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.sentenceplan.services
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.exceptions.ConflictException
 import java.util.UUID
 
 @Service
@@ -15,15 +16,20 @@ class PlanService(
   fun getPlanByOasysAssessmentPk(oasysAssessmentPk: String): PlanEntity? =
     planRepository.findByOasysAssessmentPk(oasysAssessmentPk)
 
-  fun createPlan(oasysAssessmentPk: String): PlanEntity {
-    // if a plan already exists for this PK don't add one - throw already exists
-    if (getPlanByOasysAssessmentPk(oasysAssessmentPk) == null) {
-      val plan: PlanEntity = planRepository.save(PlanEntity())
-      planRepository.createOasysAssessmentPk(oasysAssessmentPk, plan.uuid)
-      return plan
-    } else {
-      // throw an exception up the stack?
-      return PlanEntity() // placeholder so I can commit
+  fun createPlanByOasysAssessmentPk(oasysAssessmentPk: String): PlanEntity {
+    getPlanByOasysAssessmentPk(oasysAssessmentPk)?.let {
+      throw ConflictException("Plan already associated with PK: $oasysAssessmentPk")
     }
+
+    val plan = PlanEntity()
+    planRepository.save(plan)
+    planRepository.createOasysAssessmentPk(oasysAssessmentPk, plan.uuid)
+    return plan
+  }
+
+  fun createPlan(): PlanEntity {
+    val plan = PlanEntity()
+    planRepository.save(plan)
+    return plan
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
@@ -12,5 +12,18 @@ class PlanService(
 
   fun getPlanByUuid(planUuid: UUID): PlanEntity? = planRepository.findByUuid(planUuid)
 
-  fun getPlanByOasysAssessmentPk(oasysAssessmentPk: String): PlanEntity? = planRepository.findByOasysAssessmentPk(oasysAssessmentPk)
+  fun getPlanByOasysAssessmentPk(oasysAssessmentPk: String): PlanEntity? =
+    planRepository.findByOasysAssessmentPk(oasysAssessmentPk)
+
+  fun createPlan(oasysAssessmentPk: String): PlanEntity {
+    // if a plan already exists for this PK don't add one - throw already exists
+    if (getPlanByOasysAssessmentPk(oasysAssessmentPk) == null) {
+      val plan: PlanEntity = planRepository.save(PlanEntity())
+      planRepository.createOasysAssessmentPk(oasysAssessmentPk, plan.uuid)
+      return plan
+    } else {
+      // throw an exception up the stack?
+      return PlanEntity() // placeholder so I can commit
+    }
+  }
 }

--- a/src/main/resources/db/migration/V4__plan.sql
+++ b/src/main/resources/db/migration/V4__plan.sql
@@ -1,5 +1,5 @@
 do $$ begin
-    create type status_type as enum ('incomplete', 'complete', 'locked', 'signed');
+    create type status_type as enum ('INCOMPLETE', 'COMPLETE', 'LOCKED', 'SIGNED');
 exception
     when duplicate_object then null;
 end $$;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/OasysControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/OasysControllerTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.integration
 
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
@@ -10,21 +11,25 @@ import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWeb
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OasysControllerTest : IntegrationTestBase() {
 
-  @Test
-  fun `get plan by existing Oasys Assessment PK should return OK`() {
-    val oasysAssessmentPk = "1"
-    webTestClient.get().uri("/oasys/$oasysAssessmentPk")
-      .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
-      .exchange()
-      .expectStatus().isOk
-  }
+  @Nested
+  @DisplayName("getPlan")
+  inner class GetPlan {
+    @Test
+    fun `get plan by existing Oasys Assessment PK should return OK`() {
+      val oasysAssessmentPk = "1"
+      webTestClient.get().uri("/oasys/plans/$oasysAssessmentPk")
+        .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .exchange()
+        .expectStatus().isOk
+    }
 
-  @Test
-  fun `get plan by non-existent Oasys Assessment PK should return not found`() {
-    val oasysAssessmentPk = "2"
-    webTestClient.get().uri("/oasys/$oasysAssessmentPk")
-      .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
-      .exchange()
-      .expectStatus().isNotFound
+    @Test
+    fun `get plan by non-existent Oasys Assessment PK should return not found`() {
+      val oasysAssessmentPk = "2"
+      webTestClient.get().uri("/oasys/plans/$oasysAssessmentPk")
+        .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .exchange()
+        .expectStatus().isNotFound
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/OasysControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/OasysControllerTest.kt
@@ -1,15 +1,73 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.integration
 
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.cloud.contract.spec.internal.HttpStatus.CONFLICT
+import org.springframework.cloud.contract.verifier.assertion.SpringCloudContractAssertions.assertThat
+import uk.gov.justice.digital.hmpps.sentenceplan.data.CreatePlanWithOasysAssesmentPkRequest
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
+import java.util.*
 
 @AutoConfigureWebTestClient(timeout = "5s")
 @DisplayName("Oasys Controller Tests")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OasysControllerTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var planRepository: PlanRepository
+  lateinit var planUuid: UUID
+
+  @BeforeAll
+  fun setup() {
+    val plan: PlanEntity = planRepository.findAll().first()
+    planUuid = plan.uuid
+  }
+
+  @Nested
+  @DisplayName("createPlan")
+  inner class CreatePlan {
+    lateinit var planRequestBody: CreatePlanWithOasysAssesmentPkRequest
+
+    @BeforeEach
+    fun setup() {
+      planRequestBody = CreatePlanWithOasysAssesmentPkRequest(
+        oasysAssessmentPk = (0..999_999_999_999).random().toString(),
+      )
+    }
+
+    @Test
+    fun `should return created`() {
+      webTestClient.post().uri("/oasys/plans").header("Content-Type", "application/json")
+        .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .bodyValue(planRequestBody)
+        .exchange()
+        .expectStatus().isCreated
+    }
+
+    @Test
+    fun `should return conflict when oasys_assessment_PK has existing association`() {
+      val plan = planRepository.save(PlanEntity())
+      planRepository.createOasysAssessmentPk(planRequestBody.oasysAssessmentPk, plan.uuid)
+
+      val response = webTestClient.post().uri("/oasys/plans").header("Content-Type", "application/json")
+        .headers(setAuthorisation(user = "Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .bodyValue(planRequestBody)
+        .exchange()
+        .expectStatus().isEqualTo(CONFLICT)
+        .expectBody(String::class.java)
+        .returnResult()
+        .responseBody
+
+      assertThat(response).contains("Plan already associated with PK: ${planRequestBody.oasysAssessmentPk}")
+    }
+  }
 
   @Nested
   @DisplayName("getPlan")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/OasysControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/OasysControllerTest.kt
@@ -10,6 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
 import org.springframework.cloud.contract.spec.internal.HttpStatus.CONFLICT
 import org.springframework.cloud.contract.verifier.assertion.SpringCloudContractAssertions.assertThat
+import org.springframework.test.web.reactive.server.expectBody
+import uk.gov.justice.digital.hmpps.sentenceplan.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.sentenceplan.data.CreatePlanWithOasysAssesmentPkRequest
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
@@ -61,11 +63,11 @@ class OasysControllerTest : IntegrationTestBase() {
         .bodyValue(planRequestBody)
         .exchange()
         .expectStatus().isEqualTo(CONFLICT)
-        .expectBody(String::class.java)
+        .expectBody<ErrorResponse>()
         .returnResult()
         .responseBody
 
-      assertThat(response).contains("Plan already associated with PK: ${planRequestBody.oasysAssessmentPk}")
+      assertThat(response.developerMessage).contains("Plan already associated with PK: ${planRequestBody.oasysAssessmentPk}")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
@@ -1,0 +1,133 @@
+package uk.gov.justice.digital.hmpps.sentenceplan.services
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.exceptions.ConflictException
+import java.util.UUID
+
+class PlanServiceTest {
+
+  private val planRepository: PlanRepository = mockk()
+  private val planService = PlanService(planRepository)
+
+  @Nested
+  @DisplayName("gePlayByUuid")
+  inner class GetPlanByUuid {
+
+    @Test
+    fun `should return plan when plan exists with given UUID`() {
+      val planUuid = UUID.randomUUID()
+      val planEntity = PlanEntity()
+      every { planRepository.findByUuid(planUuid) } returns planEntity
+
+      val result = planService.getPlanByUuid(planUuid)
+
+      assertEquals(planEntity, result)
+    }
+
+    @Test
+    fun `should return null when no plan exists with given UUID`() {
+      val planUuid = UUID.randomUUID()
+      every { planRepository.findByUuid(planUuid) } returns null
+
+      val result = planService.getPlanByUuid(planUuid)
+
+      assertNull(result)
+    }
+  }
+
+  @Nested
+  @DisplayName("getPlanByOasysAssessmentPk")
+  inner class GetPlanByOasysAssessmentPk {
+
+    @Test
+    fun `should return plan when plan exists with given oasys assessment pk`() {
+      val oasysAssessmentPk = "123456"
+      val planEntity = PlanEntity()
+      every { planRepository.findByOasysAssessmentPk(oasysAssessmentPk) } returns planEntity
+
+      val result = planService.getPlanByOasysAssessmentPk(oasysAssessmentPk)
+
+      assertEquals(planEntity, result)
+    }
+
+    @Test
+    fun `should return null when no plan exists with given oasys assessment pk`() {
+      val oasysAssessmentPk = "123456"
+      every { planRepository.findByOasysAssessmentPk(oasysAssessmentPk) } returns null
+
+      val result = planService.getPlanByOasysAssessmentPk(oasysAssessmentPk)
+
+      assertNull(result)
+    }
+  }
+
+  @Nested
+  @DisplayName("createPlanByOasysAssessmentPk")
+  inner class CreatePlanByOasysAssessmentPk {
+
+    @Test
+    fun `should create and return plan when no plan exists with given oasys assessment pk`() {
+      val oasysAssessmentPk = "123456"
+      val planEntity = PlanEntity()
+
+      every { planRepository.findByOasysAssessmentPk(oasysAssessmentPk) } returns null
+      every { planRepository.save(any()) } returns planEntity
+      every { planRepository.createOasysAssessmentPk(oasysAssessmentPk, any()) } returns Unit
+
+      val result = planService.createPlanByOasysAssessmentPk(oasysAssessmentPk)
+
+      verify {
+        planRepository.save(
+          withArg {
+            assertEquals(result.uuid, it.uuid)
+          },
+        )
+      }
+
+      verify {
+        planRepository.createOasysAssessmentPk(
+          withArg { assertEquals(oasysAssessmentPk, it) },
+          withArg { assertEquals(result.uuid, it) },
+        )
+      }
+    }
+
+    @Test
+    fun `should throw ConflictException when plan already exists with given oasys assessment PK`() {
+      val oasysAssessmentPk = "123456"
+      val existingPlan = PlanEntity()
+      every { planRepository.findByOasysAssessmentPk(oasysAssessmentPk) } returns existingPlan
+
+      val exception = assertThrows(ConflictException::class.java) {
+        planService.createPlanByOasysAssessmentPk(oasysAssessmentPk)
+      }
+
+      assertEquals("Plan already associated with PK: $oasysAssessmentPk", exception.message)
+    }
+  }
+
+  @Nested
+  @DisplayName("createPlan")
+  inner class CreatePlan {
+
+    @Test
+    fun `should create and return a new plan`() {
+      every { planRepository.save(any()) } returns any()
+
+      val result = planService.createPlan()
+
+      verify { planRepository.save(withArg { assertEquals(result, it) }) }
+    }
+  }
+}

--- a/src/test/resources/db/migration/V900__add_plan_data.sql
+++ b/src/test/resources/db/migration/V900__add_plan_data.sql
@@ -1,1 +1,1 @@
-insert into plan(uuid, status, creation_date, updated_date) values ('556db5c8-a1eb-4064-986b-0740d6a83c33', 'incomplete','2024-06-25 10:00:00', '2024-06-25 10:00:00')
+insert into plan(uuid, status, creation_date, updated_date) values ('556db5c8-a1eb-4064-986b-0740d6a83c33', 'INCOMPLETE','2024-06-25 10:00:00', '2024-06-25 10:00:00')

--- a/src/test/resources/db/migration/V901__add_oasys_assessment_pk_data.sql
+++ b/src/test/resources/db/migration/V901__add_oasys_assessment_pk_data.sql
@@ -1,1 +1,1 @@
-INSERT INTO oasys_pk_to_plan (id, oasys_assessment_pk, plan_uuid) VALUES (1, '1', '556db5c8-a1eb-4064-986b-0740d6a83c33');
+INSERT INTO oasys_pk_to_plan (oasys_assessment_pk, plan_uuid) VALUES ('1', '556db5c8-a1eb-4064-986b-0740d6a83c33');


### PR DESCRIPTION
- Added logic for adding plans with associated oasys assessment pk through /oasys/plans
- Added logic for adding plans without an associated oasys assessment pk
   -  Note: This will go unused for now, until migration away from OASys is complete, but for clarity sake I've added it now
 - Refactored existing /oasys/ endpoints to be /oasys/plans/
 - Updated tests