### PR TITLE
Adds error handling to Area of Need lookup

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/AreaOfNeedEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/AreaOfNeedEntity.kt
@@ -36,7 +36,7 @@ interface AreaOfNeedRepository : JpaRepository<AreaOfNeedEntity, Long> {
 
   fun findByUuid(uuid: UUID): AreaOfNeedEntity
 
-  fun findByName(name: String): AreaOfNeedEntity
+  fun findByNameIgnoreCase(name: String): AreaOfNeedEntity?
 
   @Modifying
   @Transactional

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
@@ -30,11 +30,12 @@ class GoalService(
 
   @Transactional
   fun createNewGoal(planUuid: UUID, goal: Goal): GoalEntity {
-    val areaOfNeedUuid = areaOfNeedRepository.findByName(goal.areaOfNeed).uuid
+    val areaOfNeed = areaOfNeedRepository.findByNameIgnoreCase(goal.areaOfNeed)
+      ?: throw Exception("This Area of Need is not recognised: ${goal.areaOfNeed}")
 
     val goalEntity = GoalEntity(
       title = goal.title,
-      areaOfNeedUuid = areaOfNeedUuid,
+      areaOfNeedUuid = areaOfNeed.uuid,
       targetDate = goal.targetDate,
       planUuid = planUuid,
     )


### PR DESCRIPTION
Catches an exception when Area Of Need is not matched, or the casing is different to the version in the database