### PR TITLE
SP2-671 Adds PUT for steps

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/GoalController.kt
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -57,8 +58,7 @@ class GoalController(private val service: GoalService) {
     @PathVariable goalUuid: UUID,
     @RequestBody steps: List<Step>,
   ): List<StepEntity> {
-    val goal: GoalEntity = service.createNewSteps(goalUuid, steps)
-    return goal.steps
+    return service.createNewSteps(goalUuid, steps)
   }
 
   @GetMapping("/{goalUuid}/steps")
@@ -68,6 +68,15 @@ class GoalController(private val service: GoalService) {
   ): List<StepEntity> {
     val goal: GoalEntity = service.getGoalByUuid(goalUuid) ?: throw NoResourceFoundException(HttpMethod.GET, "No goal found for $goalUuid")
     return goal.steps
+  }
+
+  @PutMapping("/{goalUuid}/steps")
+  fun updateStep(
+    @PathVariable goalUuid: UUID,
+    @RequestBody steps: List<Step>,
+  ): List<StepEntity> {
+    // TODO yikes change how errors are handled: https://github.com/ministryofjustice/hmpps-sentence-plan/compare/main...goalcontroller-consistency
+    return service.updateSteps(goalUuid, steps) ?: throw NoResourceFoundException(HttpMethod.PUT, "No goal found for $goalUuid")
   }
 
   @PostMapping("/order")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/GoalController.kt
@@ -58,7 +58,7 @@ class GoalController(private val service: GoalService) {
     @PathVariable goalUuid: UUID,
     @RequestBody steps: List<Step>,
   ): List<StepEntity> {
-    return service.createNewSteps(goalUuid, steps)
+    return service.addStepsToGoal(goalUuid, steps)
   }
 
   @GetMapping("/{goalUuid}/steps")
@@ -71,12 +71,12 @@ class GoalController(private val service: GoalService) {
   }
 
   @PutMapping("/{goalUuid}/steps")
+  @ResponseStatus(HttpStatus.OK)
   fun updateStep(
     @PathVariable goalUuid: UUID,
     @RequestBody steps: List<Step>,
-  ): List<StepEntity> {
-    // TODO yikes change how errors are handled: https://github.com/ministryofjustice/hmpps-sentence-plan/compare/main...goalcontroller-consistency
-    return service.updateSteps(goalUuid, steps) ?: throw NoResourceFoundException(HttpMethod.PUT, "No goal found for $goalUuid")
+  ): List<StepEntity>? {
+    return service.addStepsToGoal(goalUuid, steps, true)
   }
 
   @PostMapping("/order")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/StepController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/StepController.kt
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.resource.NoResourceFoundException
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.services.StepService
-import java.util.*
+import java.util.UUID
 
 @RestController
 @RequestMapping("/steps")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
@@ -85,33 +85,22 @@ class GoalService(
   }
 
   @Transactional
-  fun createNewSteps(goalUuid: UUID, steps: List<Step>): List<StepEntity> {
+  fun addStepsToGoal(goalUuid: UUID, steps: List<Step>, replaceExistingSteps: Boolean = false): List<StepEntity> {
     val goal: GoalEntity = goalRepository.findByUuid(goalUuid)
-      ?: throw Exception("This Goal is not found: $goalUuid")
-
-    if (steps.isNotEmpty()) {
-      requireStepsAreValid(steps)
-    }
-
-    goal.steps = createStepEntitiesFromSteps(goal, steps)
-    return goalRepository.save(goal).steps
-  }
-
-  @Transactional
-  fun updateSteps(goalUuid: UUID, steps: List<Step>): List<StepEntity>? {
-    var goalEntity: GoalEntity = goalRepository.findByUuid(goalUuid)
       ?: throw Exception("This Goal is not found: $goalUuid")
 
     require(steps.isNotEmpty()) { "At least one Step must be provided" }
 
     requireStepsAreValid(steps)
 
-    stepRepository.deleteAll(goalEntity.steps)
+    if (replaceExistingSteps) {
+      stepRepository.deleteAll(goal.steps)
+    }
 
-    goalEntity.steps = createStepEntitiesFromSteps(goalEntity, steps)
+    goal.steps = createStepEntitiesFromSteps(goal, steps)
 
-    goalEntity = goalRepository.save(goalEntity)
-    return goalEntity.steps
+    val savedGoal: GoalEntity = goalRepository.save(goal)
+    return savedGoal.steps
   }
 
   private fun requireStepsAreValid(steps: List<Step>) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.integration
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -347,5 +348,26 @@ class GoalControllerTest : IntegrationTestBase() {
         .returnResult().responseBody
 
     assertThat(goalEntity?.relatedAreasOfNeed).isEmpty()
+  }
+
+  @Test
+  fun `update steps should return list of new entities`() {
+    fail<Nothing>("Not yet implemented")
+    // also check for no orphans in DB
+  }
+
+  @Test
+  fun `update steps should fail for an unknown goal`() {
+    fail<Nothing>("Not yet implemented")
+  }
+
+  @Test
+  fun `update steps should fail for a known goal when one step is incomplete`() {
+    fail<Nothing>("Not yet implemented")
+  }
+
+  @Test
+  fun `update steps should fail for a known goal when list of steps is empty`() {
+    fail<Nothing>("Not yet implemented")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepRepository
 import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
@@ -27,7 +28,8 @@ class GoalServiceTest {
   private val goalRepository: GoalRepository = mockk()
   private val areaOfNeedRepository: AreaOfNeedRepository = mockk()
   private val planRepository: PlanRepository = mockk()
-  private val goalService = GoalService(goalRepository, areaOfNeedRepository, planRepository)
+  private val stepRepository: StepRepository = mockk()
+  private val goalService = GoalService(goalRepository, areaOfNeedRepository, planRepository, stepRepository)
   private val goalUuid = UUID.fromString("ef74ee4b-5a0b-481b-860f-19187260f2e7")
 
   private val goal: Goal = Goal(
@@ -326,8 +328,9 @@ class GoalServiceTest {
           description = "Initial step description",
           status = "Initial status",
           actor = "Initial actor",
-          goal = goalEntityWithOneStep
-        ))
+          goal = goalEntityWithOneStep,
+        ),
+      )
 
       every { goalRepository.findByUuid(goalUuid) } returns goalEntityNoSteps
       every { goalRepository.save(capture(goalSlot)) } answers { goalSlot.captured }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
@@ -317,7 +317,7 @@ class GoalServiceTest {
     fun `update steps for goal with an existing step only returns the new steps`() {
       val goalSlot = slot<GoalEntity>()
 
-      val goalEntityWithOneStep: GoalEntity = GoalEntity(
+      val goalEntityWithOneStep = GoalEntity(
         title = "Mock Goal",
         areaOfNeed = mockk<AreaOfNeedEntity>(),
         plan = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
@@ -188,7 +188,7 @@ class GoalServiceTest {
       every { goalRepository.findByUuid(goalUuid) } returns goalEntityNoSteps
       every { goalRepository.save(capture(goalSlot)) } answers { goalSlot.captured }
 
-      val stepsList = goalService.createNewSteps(goalUuid, steps)
+      val stepsList = goalService.addStepsToGoal(goalUuid, steps)
 
       assertThat(stepsList.size).isEqualTo(2)
 
@@ -264,7 +264,7 @@ class GoalServiceTest {
       every { goalRepository.findByUuid(any()) } returns null
 
       val exception = assertThrows<Exception> {
-        goalService.updateSteps(UUID.randomUUID(), steps)
+        goalService.addStepsToGoal(UUID.randomUUID(), steps, true)
       }
 
       assertThat(exception.message).startsWith("This Goal is not found:")
@@ -275,7 +275,7 @@ class GoalServiceTest {
       every { goalRepository.findByUuid(any()) } returns goalEntityNoSteps
 
       val exception = assertThrows<Exception> {
-        goalService.updateSteps(UUID.randomUUID(), emptyList())
+        goalService.addStepsToGoal(UUID.randomUUID(), emptyList(), true)
       }
 
       assertThat(exception.message).startsWith("At least one Step must be provided")
@@ -286,7 +286,7 @@ class GoalServiceTest {
       every { goalRepository.findByUuid(any()) } returns goalEntityNoSteps
 
       val exception = assertThrows<Exception> {
-        goalService.updateSteps(UUID.randomUUID(), incompleteSteps)
+        goalService.addStepsToGoal(UUID.randomUUID(), incompleteSteps, true)
       }
 
       assertThat(exception.message).startsWith("All Steps must contain all the required information")
@@ -297,8 +297,9 @@ class GoalServiceTest {
       val goalSlot = slot<GoalEntity>()
       every { goalRepository.findByUuid(goalUuid) } returns goalEntityNoSteps
       every { goalRepository.save(capture(goalSlot)) } answers { goalSlot.captured }
+      every { stepRepository.deleteAll(any()) } returns Unit
 
-      val stepsList = goalService.updateSteps(goalUuid, steps)!!
+      val stepsList = goalService.addStepsToGoal(goalUuid, steps, true)
 
       assertThat(stepsList.size).isEqualTo(2)
 
@@ -334,8 +335,9 @@ class GoalServiceTest {
 
       every { goalRepository.findByUuid(goalUuid) } returns goalEntityNoSteps
       every { goalRepository.save(capture(goalSlot)) } answers { goalSlot.captured }
+      every { stepRepository.deleteAll(any()) } returns Unit
 
-      val stepsList = goalService.updateSteps(goalUuid, steps)!!
+      val stepsList = goalService.addStepsToGoal(goalUuid, steps, true)
 
       assertThat(stepsList.size).isEqualTo(2)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
@@ -274,7 +274,7 @@ class GoalServiceTest {
     fun `update steps with an empty list should throw an exception`() {
       every { goalRepository.findByUuid(any()) } returns goalEntityNoSteps
 
-      val exception = assertThrows<Exception> {
+      val exception = assertThrows<IllegalArgumentException> {
         goalService.addStepsToGoal(UUID.randomUUID(), emptyList(), true)
       }
 
@@ -285,7 +285,7 @@ class GoalServiceTest {
     fun `update steps where a step is incomplete should throw an exception`() {
       every { goalRepository.findByUuid(any()) } returns goalEntityNoSteps
 
-      val exception = assertThrows<Exception> {
+      val exception = assertThrows<IllegalArgumentException> {
         goalService.addStepsToGoal(UUID.randomUUID(), incompleteSteps, true)
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
 import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
@@ -82,6 +83,8 @@ class GoalServiceTest {
       actor = "actor 2",
     ),
   )
+
+  private val incompleteSteps = steps + Step("This is a step with no actor", status = "status", actor = "")
 
   @Nested
   @DisplayName("createNewGoal")
@@ -183,7 +186,7 @@ class GoalServiceTest {
       every { goalRepository.findByUuid(goalUuid) } returns goalEntityNoSteps
       every { goalRepository.save(capture(goalSlot)) } answers { goalSlot.captured }
 
-      val stepsList = goalService.createNewSteps(goalUuid, steps).steps
+      val stepsList = goalService.createNewSteps(goalUuid, steps)
 
       assertThat(stepsList.size).isEqualTo(2)
 
@@ -248,6 +251,99 @@ class GoalServiceTest {
       }
 
       assertThat(exception.message).startsWith("One or more of the Related Areas of Need was not found")
+    }
+  }
+
+  @Nested
+  @DisplayName("UpdateSteps")
+  inner class UpdateSteps {
+    @Test
+    fun `update steps for goal that does not exist should throw an exception`() {
+      every { goalRepository.findByUuid(any()) } returns null
+
+      val exception = assertThrows<Exception> {
+        goalService.updateSteps(UUID.randomUUID(), steps)
+      }
+
+      assertThat(exception.message).startsWith("This Goal is not found:")
+    }
+
+    @Test
+    fun `update steps with an empty list should throw an exception`() {
+      every { goalRepository.findByUuid(any()) } returns goalEntityNoSteps
+
+      val exception = assertThrows<Exception> {
+        goalService.updateSteps(UUID.randomUUID(), emptyList())
+      }
+
+      assertThat(exception.message).startsWith("At least one Step must be provided")
+    }
+
+    @Test
+    fun `update steps where a step is incomplete should throw an exception`() {
+      every { goalRepository.findByUuid(any()) } returns goalEntityNoSteps
+
+      val exception = assertThrows<Exception> {
+        goalService.updateSteps(UUID.randomUUID(), incompleteSteps)
+      }
+
+      assertThat(exception.message).startsWith("All Steps must contain all the required information")
+    }
+
+    @Test
+    fun `update steps for goal with no steps should return the new steps`() {
+      val goalSlot = slot<GoalEntity>()
+      every { goalRepository.findByUuid(goalUuid) } returns goalEntityNoSteps
+      every { goalRepository.save(capture(goalSlot)) } answers { goalSlot.captured }
+
+      val stepsList = goalService.updateSteps(goalUuid, steps)!!
+
+      assertThat(stepsList.size).isEqualTo(2)
+
+      assertThat(stepsList.first().status).isEqualTo("status 1")
+      assertThat(stepsList.first().goal?.uuid).isEqualTo(goalUuid)
+      assertThat(stepsList.first().description).isEqualTo("description 1")
+      assertThat(stepsList.first().actor).isEqualTo("actor 1")
+
+      assertThat(stepsList.last().status).isEqualTo("status 2")
+      assertThat(stepsList.last().goal?.uuid).isEqualTo(goalUuid)
+      assertThat(stepsList.last().description).isEqualTo("description 2")
+    }
+
+    @Test
+    fun `update steps for goal with an existing step only returns the new steps`() {
+      val goalSlot = slot<GoalEntity>()
+
+      val goalEntityWithOneStep: GoalEntity = GoalEntity(
+        title = "Mock Goal",
+        areaOfNeed = mockk<AreaOfNeedEntity>(),
+        plan = null,
+        uuid = goalUuid,
+        goalOrder = 1,
+      )
+      goalEntityWithOneStep.steps = listOf(
+        StepEntity(
+          description = "Initial step description",
+          status = "Initial status",
+          actor = "Initial actor",
+          goal = goalEntityWithOneStep
+        ))
+
+      every { goalRepository.findByUuid(goalUuid) } returns goalEntityNoSteps
+      every { goalRepository.save(capture(goalSlot)) } answers { goalSlot.captured }
+
+      val stepsList = goalService.updateSteps(goalUuid, steps)!!
+
+      assertThat(stepsList.size).isEqualTo(2)
+
+      assertThat(stepsList.first().status).isEqualTo("status 1")
+      assertThat(stepsList.first().goal?.uuid).isEqualTo(goalUuid)
+      assertThat(stepsList.first().description).isEqualTo("description 1")
+      assertThat(stepsList.first().actor).isEqualTo("actor 1")
+
+      assertThat(stepsList.last().status).isEqualTo("status 2")
+      assertThat(stepsList.last().goal?.uuid).isEqualTo(goalUuid)
+      assertThat(stepsList.last().description).isEqualTo("description 2")
     }
   }
 }

--- a/src/test/resources/db/test/update_steps_cleanup.sql
+++ b/src/test/resources/db/test/update_steps_cleanup.sql
@@ -1,0 +1,5 @@
+DELETE FROM step where goal_id = (SELECT id FROM goal where goal.uuid = 'b9c66782-1dd0-4be5-910a-001e01313420');
+
+DELETE FROM goal where plan_id = (select id from plan where plan.uuid = '5012fc38-2f13-4111-8c7e-abc3ee7e4822');
+
+DELETE FROM plan WHERE uuid = '5012fc38-2f13-4111-8c7e-abc3ee7e4822'

--- a/src/test/resources/db/test/update_steps_data.sql
+++ b/src/test/resources/db/test/update_steps_data.sql
@@ -1,0 +1,43 @@
+insert into plan(uuid, countersigning_status, agreement_status, agreement_date, creation_date, updated_date)
+values ('5012fc38-2f13-4111-8c7e-abc3ee7e4822',
+        'INCOMPLETE',
+        'DRAFT',
+        null,
+        '2024-06-25 10:00:00',
+        '2024-06-25 10:00:00');
+
+INSERT INTO goal (uuid, title, area_of_need_id, target_date, creation_date, goal_order, plan_id)
+SELECT 'b9c66782-1dd0-4be5-910a-001e01313420',
+       'Goal with no steps',
+       aon.id,
+       '2024-06-27 16:10:57.299363',
+       '2024-06-27 16:10:57.299363',
+       1,
+       plan.id
+FROM area_of_need aon,
+     plan
+where aon.name = 'Accommodation'
+  and plan.uuid = '5012fc38-2f13-4111-8c7e-abc3ee7e4822';
+
+INSERT INTO goal (uuid, title, area_of_need_id, target_date, creation_date, goal_order, plan_id)
+SELECT '8b889730-ade8-4c3c-8e06-91a78b3ff3b2',
+       'Goal with one step',
+       aon.id,
+       '2024-06-27 16:10:57.299363',
+       '2024-06-27 16:10:57.299363',
+       1,
+       plan.id
+FROM area_of_need aon,
+     plan
+where aon.name = 'Accommodation'
+  and plan.uuid = '5012fc38-2f13-4111-8c7e-abc3ee7e4822';
+
+INSERT INTO step (uuid, goal_id, description, status, creation_date, actor)
+SELECT 'fcf019dc-e9aa-44dd-ad9b-1f2f8ba06c99',
+       goal.id,
+       'Step for update steps tests',
+       'Status name',
+       '2024-06-27 16:26:38.000000',
+       'actor'
+FROM goal
+where goal.uuid = '8b889730-ade8-4c3c-8e06-91a78b3ff3b2';


### PR DESCRIPTION
Adds the ability to PUT Step objects onto an existing Goal. 

The underlying implementation function for POST and PUT of Steps is the same, with PUT triggering a `deleteAll` of existing Steps before adding the new ones.

Implementation is in GoalController and GoalService. Everything else is tidying up (StepController) or tests.