### PR TITLE
Updates GoalService to only require individual fields during an update and will update a GoalEntity based on that

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/data/Goal.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/data/Goal.kt
@@ -1,8 +1,11 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.data
 
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalStatus
+
 data class Goal(
-  val title: String,
-  val areaOfNeed: String,
+  val title: String? = null,
+  val areaOfNeed: String? = null,
   val targetDate: String? = null,
   val relatedAreasOfNeed: List<String> = emptyList(),
+  val status: GoalStatus? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/GoalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/GoalEntity.kt
@@ -21,6 +21,7 @@ import jakarta.persistence.UniqueConstraint
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import uk.gov.justice.digital.hmpps.sentenceplan.data.Goal
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 import java.util.UUID
@@ -78,7 +79,33 @@ class GoalEntity(
     uniqueConstraints = [UniqueConstraint(columnNames = ["goal_id", "area_of_need_id"])],
   )
   var relatedAreasOfNeed: MutableList<AreaOfNeedEntity>? = mutableListOf(),
-)
+) {
+
+  fun merge(goal: Goal, relatedAreasOfNeedList: List<AreaOfNeedEntity>): GoalEntity {
+    if (goal.title != null) {
+      this.title = goal.title
+    }
+
+    if (goal.targetDate != null) {
+      this.targetDate = goal.targetDate
+      if (this.status == GoalStatus.FUTURE) {
+        this.status = GoalStatus.ACTIVE
+      }
+    }
+
+    if (goal.targetDate == null && goal.status == GoalStatus.FUTURE) {
+      this.targetDate = null
+    }
+
+    if (goal.status != null) {
+      this.status = goal.status
+    }
+
+    this.relatedAreasOfNeed = relatedAreasOfNeedList.toMutableList()
+
+    return this
+  }
+}
 
 enum class GoalStatus {
   ACTIVE,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/GoalEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/GoalEntity.kt
@@ -90,6 +90,7 @@ class GoalEntity(
       this.targetDate = goal.targetDate
       if (this.status == GoalStatus.FUTURE) {
         this.status = GoalStatus.ACTIVE
+        this.statusDate = DateTimeFormatter.ISO_INSTANT.format(Instant.now())
       }
     }
 
@@ -99,6 +100,7 @@ class GoalEntity(
 
     if (goal.status != null) {
       this.status = goal.status
+      this.statusDate = DateTimeFormatter.ISO_INSTANT.format(Instant.now())
     }
 
     this.relatedAreasOfNeed = relatedAreasOfNeedList.toMutableList()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
@@ -13,6 +13,8 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalStatus
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepRepository
+import java.time.Instant
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 @Service
@@ -44,7 +46,7 @@ class GoalService(
       areaOfNeed = areaOfNeedEntity,
       targetDate = goal.targetDate,
       status = if (goal.targetDate != null) GoalStatus.ACTIVE else GoalStatus.FUTURE,
-      statusDate = null,
+      statusDate = DateTimeFormatter.ISO_INSTANT.format(Instant.now()),
       plan = planEntity,
       relatedAreasOfNeed = relatedAreasOfNeedEntity.toMutableList(),
       goalOrder = highestGoalOrder + 1,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
@@ -42,7 +42,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
   lateinit var goalRequestBody: Goal
 
-  var authUuid = UUID.randomUUID().toString()
+  val authenticatedUser = UUID.randomUUID().toString() + "|Tom C"
 
   private val goalOrder = GoalOrder(
     goalUuid = UUID.randomUUID(),
@@ -180,7 +180,7 @@ class GoalControllerTest : IntegrationTestBase() {
   fun `get goal by UUID should return OK when goal exists`() {
     val goal: GoalEntity? = webTestClient.get().uri("/goals/$TEST_DATA_GOAL_UUID")
       .header("Content-Type", "application/json")
-      .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .exchange()
       .expectStatus().isOk
       .expectBody<GoalEntity>()
@@ -195,7 +195,7 @@ class GoalControllerTest : IntegrationTestBase() {
     val randomUuid = UUID.randomUUID()
     webTestClient.get().uri("/goals/$randomUuid")
       .header("Content-Type", "application/json")
-      .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .exchange()
       .expectStatus().isNotFound
       .expectBody<ErrorResponse>()
@@ -205,7 +205,7 @@ class GoalControllerTest : IntegrationTestBase() {
   fun `get goal steps should return OK and contain 1 step`() {
     webTestClient.get().uri("/goals/$TEST_DATA_GOAL_UUID/steps")
       .header("Content-Type", "application/json")
-      .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .exchange()
       .expectStatus().isOk
       .expectBodyList<StepEntity>()
@@ -216,7 +216,7 @@ class GoalControllerTest : IntegrationTestBase() {
     val randomUuid = UUID.randomUUID()
     webTestClient.get().uri("/goals/$randomUuid/steps")
       .header("Content-Type", "application/json")
-      .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .exchange()
       .expectStatus().isNotFound
       .expectBody<ErrorResponse>()
@@ -226,7 +226,7 @@ class GoalControllerTest : IntegrationTestBase() {
   fun `create goal steps should return OK`() {
     webTestClient.post().uri("/goals/${TEST_DATA_GOAL_UUID}/steps")
       .header("Content-Type", "application/json")
-      .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .bodyValue(stepList)
       .exchange()
       .expectStatus().isCreated
@@ -238,7 +238,7 @@ class GoalControllerTest : IntegrationTestBase() {
     val randomUuid = UUID.randomUUID()
     webTestClient.post().uri("/goals/$randomUuid/steps")
       .header("Content-Type", "application/json")
-      .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .bodyValue(stepList)
       .exchange()
       .expectStatus().is5xxServerError
@@ -249,7 +249,7 @@ class GoalControllerTest : IntegrationTestBase() {
   fun `create goal steps with no steps should return 500`() {
     webTestClient.post().uri("/goals/${TEST_DATA_GOAL_UUID}/steps")
       .header("Content-Type", "application/json")
-      .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .bodyValue(emptyList<StepEntity>())
       .exchange()
       .expectStatus().is5xxServerError
@@ -260,7 +260,7 @@ class GoalControllerTest : IntegrationTestBase() {
   fun `update goals order should return created`() {
     webTestClient.post().uri("/goals/order")
       .header("Content-Type", "application/json")
-      .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .bodyValue(goalOrderList)
       .exchange()
       .expectStatus().isCreated
@@ -269,17 +269,17 @@ class GoalControllerTest : IntegrationTestBase() {
   @Test
   fun `delete goal should return no content and confirm goal and steps deleted`() {
     webTestClient.delete().uri("/goals/ede47f7f-8431-4ff9-80ec-2dd3a8db3841")
-      .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .exchange()
       .expectStatus().isNoContent
 
     webTestClient.get().uri("/goals/ede47f7f-8431-4ff9-80ec-2dd3a8db3841")
-      .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .exchange()
       .expectStatus().isNotFound
 
     webTestClient.get().uri("/steps/79803555-fad5-4cb7-8f8e-10f6d436834c")
-      .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .exchange()
       .expectStatus().isNotFound
   }
@@ -288,7 +288,7 @@ class GoalControllerTest : IntegrationTestBase() {
   fun `deleting a goal that does not exist should return 404`() {
     webTestClient.delete().uri("/goals/93ab5028-867f-4554-aa5a-2383e6b50f1f")
       .header("Content-Type", "application/json")
-      .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+      .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
       .exchange()
       .expectStatus().isNotFound
   }
@@ -310,7 +310,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
       val goalEntity: GoalEntity? =
         webTestClient.patch().uri("/goals/$goalUuid").header("Content-Type", "application/json")
-          .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+          .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
           .bodyValue(goalRequestBody)
           .exchange()
           .expectStatus().isOk
@@ -332,7 +332,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
       val goalEntity: GoalEntity? =
         webTestClient.patch().uri("/goals/$goalUuid").header("Content-Type", "application/json")
-          .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+          .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
           .bodyValue(goalRequestBody)
           .exchange()
           .expectStatus().isOk
@@ -356,7 +356,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
       val goalEntity: GoalEntity? =
         webTestClient.patch().uri("/goals/$goalUuid").header("Content-Type", "application/json")
-          .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+          .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
           .bodyValue(goalRequestBody)
           .exchange()
           .expectStatus().isOk
@@ -379,7 +379,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
       val goalEntity: GoalEntity? =
         webTestClient.patch().uri("/goals/$goalUuid").header("Content-Type", "application/json")
-          .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+          .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
           .bodyValue(goalRequestBody)
           .exchange()
           .expectStatus().isOk
@@ -402,7 +402,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
       val goalEntity: GoalEntity? =
         webTestClient.patch().uri("/goals/$goalUuid").header("Content-Type", "application/json")
-          .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+          .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
           .bodyValue(goalRequestBody)
           .exchange()
           .expectStatus().isOk
@@ -423,7 +423,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
       val goalEntity: GoalEntity? =
         webTestClient.patch().uri("/goals/$goalUuid").header("Content-Type", "application/json")
-          .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+          .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
           .bodyValue(goalRequestBody)
           .exchange()
           .expectStatus().isOk
@@ -446,7 +446,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
       val steps: List<StepEntity>? = webTestClient.put().uri("/goals/$goalWithNoStepsUuid/steps")
         .header("Content-Type", "application/json")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .bodyValue(stepList)
         .exchange()
         .expectStatus().isOk
@@ -464,7 +464,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
       val steps: List<StepEntity>? = webTestClient.put().uri("/goals/$goalWithOneStepUuid/steps")
         .header("Content-Type", "application/json")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .bodyValue(stepList)
         .exchange()
         .expectStatus().isOk
@@ -478,7 +478,7 @@ class GoalControllerTest : IntegrationTestBase() {
       // refetch goal to make sure there are no surprise steps still attached
       val goal: GoalEntity? = webTestClient.get().uri("/goals/$goalWithOneStepUuid")
         .header("Content-Type", "application/json")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .exchange()
         .expectStatus().isOk
         .expectBody<GoalEntity>()
@@ -493,7 +493,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
       webTestClient.get().uri("/steps/$originalGoalStepUuid")
         .header("Content-Type", "application/json")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .exchange()
         .expectStatus().isNotFound
         .expectBody<ErrorResponse>()
@@ -505,7 +505,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
       webTestClient.put().uri("/goals/$goalUuid/steps")
         .header("Content-Type", "application/json")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .bodyValue(stepList)
         .exchange()
         .expectStatus().is5xxServerError
@@ -526,7 +526,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
       webTestClient.put().uri("/goals/$goalWithNoStepsUuid/steps")
         .header("Content-Type", "application/json")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .bodyValue(listWithIncompleteStep)
         .exchange()
         .expectStatus().is5xxServerError
@@ -539,7 +539,7 @@ class GoalControllerTest : IntegrationTestBase() {
 
       webTestClient.put().uri("/goals/$goalWithNoStepsUuid/steps")
         .header("Content-Type", "application/json")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .bodyValue(emptyList<Step>())
         .exchange()
         .expectStatus().is5xxServerError

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/OasysControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/OasysControllerTest.kt
@@ -27,7 +27,7 @@ class OasysControllerTest : IntegrationTestBase() {
   lateinit var planRepository: PlanRepository
   lateinit var planUuid: UUID
 
-  var authUuid = UUID.randomUUID().toString()
+  val authenticatedUser = UUID.randomUUID().toString() + "|Tom C"
 
   @BeforeAll
   fun setup() {
@@ -50,7 +50,7 @@ class OasysControllerTest : IntegrationTestBase() {
     @Test
     fun `should return created`() {
       webTestClient.post().uri("/oasys/plans").header("Content-Type", "application/json")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .bodyValue(planRequestBody)
         .exchange()
         .expectStatus().isCreated
@@ -63,7 +63,7 @@ class OasysControllerTest : IntegrationTestBase() {
       planRepository.createOasysAssessmentPk(planRequestBody.oasysAssessmentPk, plan.uuid)
 
       val response = webTestClient.post().uri("/oasys/plans").header("Content-Type", "application/json")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .bodyValue(planRequestBody)
         .exchange()
         .expectStatus().isEqualTo(HttpStatus.CONFLICT)
@@ -82,7 +82,7 @@ class OasysControllerTest : IntegrationTestBase() {
     fun `get plan by existing Oasys Assessment PK should return OK`() {
       val oasysAssessmentPk = "1"
       webTestClient.get().uri("/oasys/plans/$oasysAssessmentPk")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .exchange()
         .expectStatus().isOk
     }
@@ -91,7 +91,7 @@ class OasysControllerTest : IntegrationTestBase() {
     fun `get plan by non-existent Oasys Assessment PK should return not found`() {
       val oasysAssessmentPk = "2"
       webTestClient.get().uri("/oasys/plans/$oasysAssessmentPk")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .exchange()
         .expectStatus().isNotFound
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/PlanControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/PlanControllerTest.kt
@@ -33,7 +33,7 @@ import java.util.UUID
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PlanControllerTest : IntegrationTestBase() {
 
-  var authUuid = UUID.randomUUID().toString()
+  val authenticatedUser = UUID.randomUUID().toString() + "|Tom C"
   val staticPlanUuid = "556db5c8-a1eb-4064-986b-0740d6a83c33"
   val mutablePlanUuid = "4fe411e3-820d-4198-8400-ab4268208641"
 
@@ -45,7 +45,7 @@ class PlanControllerTest : IntegrationTestBase() {
       val testStartTime = Instant.now()
 
       val planEntity: PlanEntity? = webTestClient.post().uri("/plans").header("Content-Type", "application/json")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .exchange()
         .expectStatus().isCreated
         .expectBody<PlanEntity>()
@@ -62,7 +62,7 @@ class PlanControllerTest : IntegrationTestBase() {
     @Test
     fun `should return OK when getting plan by existing UUID `() {
       val planEntity: PlanEntity? = webTestClient.get().uri("/plans/$staticPlanUuid")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .exchange()
         .expectStatus().isOk
         .expectBody<PlanEntity>()
@@ -75,7 +75,7 @@ class PlanControllerTest : IntegrationTestBase() {
     fun `should return not found when getting plan by non-existent UUID`() {
       val randomPlanUuid = UUID.randomUUID()
       webTestClient.get().uri("/plans/$randomPlanUuid")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .exchange()
         .expectStatus().isNotFound
     }
@@ -89,7 +89,7 @@ class PlanControllerTest : IntegrationTestBase() {
       val goalsMap: Map<String, List<GoalEntity>>? =
         webTestClient.get().uri("/plans/$staticPlanUuid/goals")
           .header("Content-Type", "application/json")
-          .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+          .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
           .exchange()
           .expectStatus().isOk
           .expectBody<Map<String, List<GoalEntity>>>()
@@ -106,7 +106,7 @@ class PlanControllerTest : IntegrationTestBase() {
       val randomPlanUuid = UUID.randomUUID()
       webTestClient.get().uri("/plans/$randomPlanUuid/goals")
         .header("Content-Type", "application/json")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .exchange()
         .expectStatus().isNotFound
         .expectBodyList<ErrorResponse>()
@@ -135,7 +135,7 @@ class PlanControllerTest : IntegrationTestBase() {
         targetDate = LocalDateTime.now().toString(),
       )
       webTestClient.post().uri("/plans/$staticPlanUuid/goals").header("Content-Type", "application/json")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .bodyValue(goalRequestBodyBadAreaOfNeed)
         .exchange()
         .expectStatus().is5xxServerError
@@ -151,7 +151,7 @@ class PlanControllerTest : IntegrationTestBase() {
       )
       val randomUuid = UUID.randomUUID()
       val errorResponse: ErrorResponse? = webTestClient.post().uri("/plans/$randomUuid/goals").header("Content-Type", "application/json")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .bodyValue(goalRequestBodyBadAreaOfNeed)
         .exchange()
         .expectStatus().is5xxServerError
@@ -169,7 +169,7 @@ class PlanControllerTest : IntegrationTestBase() {
       )
       val goalEntity: GoalEntity? =
         webTestClient.post().uri("/plans/$mutablePlanUuid/goals").header("Content-Type", "application/json")
-          .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+          .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
           .bodyValue(goalRequestBodyWithNoTargetDate)
           .exchange()
           .expectStatus().isCreated
@@ -184,7 +184,7 @@ class PlanControllerTest : IntegrationTestBase() {
     fun `should create goal with a target date`() {
       val goalEntity: GoalEntity? =
         webTestClient.post().uri("/plans/$mutablePlanUuid/goals").header("Content-Type", "application/json")
-          .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+          .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
           .bodyValue(goalRequestBody)
           .exchange()
           .expectStatus().isCreated
@@ -204,7 +204,7 @@ class PlanControllerTest : IntegrationTestBase() {
       )
       val goalEntity: GoalEntity? =
         webTestClient.post().uri("/plans/$mutablePlanUuid/goals").header("Content-Type", "application/json")
-          .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+          .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
           .bodyValue(goalRequestBodyUppercaseAreaOfNeed)
           .exchange()
           .expectStatus().isCreated
@@ -218,7 +218,7 @@ class PlanControllerTest : IntegrationTestBase() {
     fun `should return created when creating goal with no related areas of need`() {
       val goalEntity: GoalEntity? =
         webTestClient.post().uri("/plans/$mutablePlanUuid/goals").header("Content-Type", "application/json")
-          .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+          .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
           .bodyValue(goalRequestBody)
           .exchange()
           .expectStatus().isCreated
@@ -240,7 +240,7 @@ class PlanControllerTest : IntegrationTestBase() {
       )
       val goalEntity: GoalEntity? =
         webTestClient.post().uri("/plans/$mutablePlanUuid/goals").header("Content-Type", "application/json")
-          .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+          .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
           .bodyValue(goalRequestBody)
           .exchange()
           .expectStatus().isCreated
@@ -256,7 +256,7 @@ class PlanControllerTest : IntegrationTestBase() {
     fun `should return server error when creating goal with invalid Plan UUID`() {
       val randomPlanUuid = UUID.randomUUID()
       webTestClient.post().uri("/plans/$randomPlanUuid/goals").header("Content-Type", "application/json")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .bodyValue(goalRequestBody)
         .exchange()
         .expectStatus().is5xxServerError
@@ -285,7 +285,7 @@ class PlanControllerTest : IntegrationTestBase() {
 
       val planEntity: PlanEntity? = webTestClient.post().uri("/plans/650df4b2-f74d-4ab7-85a1-143d2a7d8cfe/agree")
         .header("Content-Type", "application/json")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .bodyValue(agreePlanBody)
         .exchange()
         .expectStatus().isAccepted
@@ -303,7 +303,7 @@ class PlanControllerTest : IntegrationTestBase() {
     fun `plan has already been agreed`() {
       webTestClient.post().uri("/plans/650df4b2-f74d-4ab7-85a1-143d2a7d8cfe/agree")
         .header("Content-Type", "application/json")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .bodyValue(agreePlanBody)
         .exchange()
         .expectStatus().isEqualTo(HttpStatus.CONFLICT)
@@ -313,7 +313,7 @@ class PlanControllerTest : IntegrationTestBase() {
     fun `plan not found`() {
       webTestClient.post().uri("/plans/e0b7707e-a9da-4574-b97f-ea84e402baf6/agree")
         .header("Content-Type", "application/json")
-        .headers(setAuthorisation(user = authUuid + "|Tom C", roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
         .bodyValue(agreePlanBody)
         .exchange()
         .expectStatus().isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY)

--- a/src/test/resources/db/test/update_goals_cleanup.sql
+++ b/src/test/resources/db/test/update_goals_cleanup.sql
@@ -1,0 +1,5 @@
+DELETE FROM related_area_of_need WHERE goal_id in (select id from goal where plan_id in (select id from plan where plan.uuid='d1e159a3-e5dc-4464-8b52-59f578100833'));
+
+DELETE FROM goal where plan_id = (select id from plan where plan.uuid = 'd1e159a3-e5dc-4464-8b52-59f578100833');
+
+DELETE FROM plan WHERE uuid = 'd1e159a3-e5dc-4464-8b52-59f578100833'

--- a/src/test/resources/db/test/update_goals_data.sql
+++ b/src/test/resources/db/test/update_goals_data.sql
@@ -1,8 +1,14 @@
 insert into plan(uuid, countersigning_status, agreement_status, agreement_date, creation_date, updated_date) values ('d1e159a3-e5dc-4464-8b52-59f578100833', 'INCOMPLETE', 'DRAFT',null, '2024-06-25 10:00:00', '2024-06-25 10:00:00');
 
 INSERT INTO goal (uuid, title, area_of_need_id, target_date, creation_date, goal_status, status_date, goal_order, plan_id)
-SELECT '070442be-f855-4eb6-af7e-72f68aab54be', 'Goal For Updating', aon.id, null,
+SELECT '070442be-f855-4eb6-af7e-72f68aab54be', 'Future Goal For Updating', aon.id, null,
        '2024-06-27 16:10:57.299363', 'FUTURE', null, 3, plan.id
+FROM
+    area_of_need aon, plan where aon.name='Accommodation' and plan.uuid='d1e159a3-e5dc-4464-8b52-59f578100833';
+
+INSERT INTO goal (uuid, title, area_of_need_id, target_date, creation_date, goal_status, status_date, goal_order, plan_id)
+SELECT '379f986a-c4f8-4c27-bdda-2ccb0aebb6a6', 'Active Goal For Updating', aon.id, '2032-09-12 17:00:00',
+       '2024-06-27 16:10:57.299363', 'ACTIVE', null, 4, plan.id
 FROM
     area_of_need aon, plan where aon.name='Accommodation' and plan.uuid='d1e159a3-e5dc-4464-8b52-59f578100833';
 


### PR DESCRIPTION
Also refactors the Update Goal tests to use a discrete SQL file rather than the Flyway migrations.