### PR TITLE
Adds support for creating a copy of an existing PlanVersion

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/GoalController.kt
@@ -49,7 +49,9 @@ class GoalController(private val service: GoalService) {
   fun deleteGoal(
     @PathVariable goalUuid: UUID,
   ) {
-    service.deleteGoal(goalUuid) ?: throw NoResourceFoundException(HttpMethod.DELETE, "No goal found for $goalUuid")
+    if (service.deleteGoalByUuid(goalUuid) != 1) {
+      throw NoResourceFoundException(HttpMethod.DELETE, "No goal found for $goalUuid")
+    }
   }
 
   @PostMapping("/{goalUuid}/steps")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/GoalController.kt
@@ -21,6 +21,8 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.services.GoalService
 import java.util.UUID
 
+private const val ONE_ROW_DELETED = 1
+
 @RestController
 @RequestMapping("/goals")
 class GoalController(private val service: GoalService) {
@@ -49,7 +51,7 @@ class GoalController(private val service: GoalService) {
   fun deleteGoal(
     @PathVariable goalUuid: UUID,
   ) {
-    if (service.deleteGoalByUuid(goalUuid) != 1) {
+    if (service.deleteGoalByUuid(goalUuid) != ONE_ROW_DELETED) {
       throw NoResourceFoundException(HttpMethod.DELETE, "No goal found for $goalUuid")
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanAgreementNoteEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanAgreementNoteEntity.kt
@@ -28,12 +28,12 @@ class PlanAgreementNoteEntity(
   @Column(name = "id")
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @JsonIgnore
-  val id: Long? = null,
+  var id: Long? = null,
 
   @OneToOne(cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
   @JoinColumn(name = "plan_version_id", referencedColumnName = "id")
   @JsonIgnore
-  val planVersion: PlanVersionEntity?,
+  var planVersion: PlanVersionEntity?,
 
   @Column(name = "optional_note")
   var optionalNote: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanEntity.kt
@@ -62,7 +62,8 @@ class PlanEntity(
   var lastUpdatedBy: PractitionerEntity? = null,
 
   // this is nullable because PlanEntity and PlanVersionEntity link to each other. We must have a PlanEntity.ID before we can save a PlanVersionEntity
-  @OneToOne(mappedBy = "plan")
+  @OneToOne()
+  @JoinColumn(name = "current_plan_version_id")
   var currentVersion: PlanVersionEntity? = null,
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanProgressNoteEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanProgressNoteEntity.kt
@@ -17,6 +17,7 @@ import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import org.springframework.data.jpa.repository.JpaRepository
 import java.time.LocalDateTime
+import java.util.UUID
 
 @Entity(name = "PlanProgressNote")
 @Table(name = "plan_progress_notes")
@@ -26,12 +27,12 @@ class PlanProgressNoteEntity(
   @Column(name = "id")
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @JsonIgnore
-  val id: Long? = null,
+  var id: Long? = null,
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "plan_version_id", referencedColumnName = "id")
   @JsonIgnore
-  val planVersion: PlanVersionEntity?,
+  var planVersion: PlanVersionEntity?,
 
   @Column(name = "note")
   var note: String,
@@ -70,4 +71,6 @@ enum class NoteIsSupportNeeded {
   DONT_KNOW,
 }
 
-interface PlanProgressNotesRepository : JpaRepository<PlanProgressNoteEntity, Long>
+interface PlanProgressNotesRepository : JpaRepository<PlanProgressNoteEntity, Long> {
+  fun findByPlanVersionUuid(planVersionUuid: UUID): List<PlanProgressNoteEntity>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/StepEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/StepEntity.kt
@@ -27,16 +27,16 @@ class StepEntity(
   @Column(name = "id")
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @JsonIgnore
-  val id: Long? = null,
+  var id: Long? = null,
 
   @Column(name = "uuid")
-  val uuid: UUID = UUID.randomUUID(),
+  var uuid: UUID = UUID.randomUUID(),
 
   // this is nullable in the declaration to enable ignoring the field in JSON serialisation
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "goal_id", nullable = false)
   @JsonIgnore
-  val goal: GoalEntity? = null,
+  var goal: GoalEntity? = null,
 
   @Column(name = "description")
   val description: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalStatus
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepRepository
 import java.time.LocalDate
@@ -24,16 +23,14 @@ import java.util.UUID
 class GoalService(
   private val goalRepository: GoalRepository,
   private val areaOfNeedRepository: AreaOfNeedRepository,
-  private val planVersionRepository: PlanVersionRepository,
   private val stepRepository: StepRepository,
   private val planRepository: PlanRepository,
 ) {
-
   fun getGoalByUuid(goalUuid: UUID): GoalEntity? = goalRepository.findByUuid(goalUuid)
 
   @Transactional
   fun createNewGoal(planUuid: UUID, goal: Goal): GoalEntity {
-    var planVersionEntity: PlanVersionEntity
+    val planVersionEntity: PlanVersionEntity
 
     try {
       planVersionEntity = planRepository.findByUuid(planUuid).currentVersion!!
@@ -62,7 +59,7 @@ class GoalService(
       status = if (goal.targetDate != null) GoalStatus.ACTIVE else GoalStatus.FUTURE,
       statusDate = LocalDateTime.now(),
       planVersion = planVersionEntity,
-      relatedAreasOfNeed = relatedAreasOfNeedEntity.toMutableList(),
+      relatedAreasOfNeed = relatedAreasOfNeedEntity.toMutableSet(),
       goalOrder = highestGoalOrder + 1,
     )
     val savedGoalEntity = goalRepository.save(goalEntity)
@@ -143,8 +140,8 @@ class GoalService(
   }
 
   @Transactional
-  fun deleteGoal(goalUuid: UUID): Unit? {
-    val goalEntity: GoalEntity? = goalRepository.findByUuid(goalUuid)
-    return goalEntity?.let { goalRepository.delete(it) }
+  fun deleteGoalByUuid(goalUuid: UUID): Int {
+    val goalsDeletedCount = goalRepository.deleteByUuid(goalUuid)
+    return goalsDeletedCount
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
@@ -141,7 +141,6 @@ class GoalService(
 
   @Transactional
   fun deleteGoalByUuid(goalUuid: UUID): Int {
-    val goalsDeletedCount = goalRepository.deleteByUuid(goalUuid)
-    return goalsDeletedCount
+    return goalRepository.deleteByUuid(goalUuid)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
@@ -35,29 +35,25 @@ class PlanService(
       throw ConflictException("Plan already associated with PK: $oasysAssessmentPk")
     }
 
-    val plan = PlanEntity()
-    val planEntity = planRepository.save(plan)
-
-    val planVersion = PlanVersionEntity(plan = planEntity)
-    val planVersionEntity = planVersionRepository.save(planVersion)
-
-    planEntity.currentVersion = planVersionEntity
-    planRepository.save(planEntity)
-
+    val planEntity = createPlan(PlanType.INITIAL)
     planRepository.createOasysAssessmentPk(oasysAssessmentPk, planEntity.id!!)
     return planEntity
   }
 
   fun createPlan(planType: PlanType): PlanEntity {
-    val plan = PlanEntity()
-    val planEntity = planRepository.save(plan)
+    val planEntity = planRepository.save(PlanEntity())
 
-    val planVersion = PlanVersionEntity(plan = planEntity)
-    planVersion.apply {
-      this.planType = planType
-      this.version = 0
-    }
-    planVersionRepository.save(planVersion)
+    val planVersion = PlanVersionEntity(
+      plan = planEntity,
+      planId = planEntity.id!!,
+      planType = planType,
+      version = 0,
+    )
+
+    val planVersionEntity = planVersionRepository.save(planVersion)
+
+    planEntity.currentVersion = planVersionEntity
+    planRepository.save(planEntity)
 
     return planEntity
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionService.kt
@@ -1,0 +1,75 @@
+package uk.gov.justice.digital.hmpps.sentenceplan.services
+
+import jakarta.persistence.EntityManager
+import jakarta.persistence.NoResultException
+import jakarta.persistence.PersistenceContext
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.AreaOfNeedEntity
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
+import java.util.UUID
+
+@Service
+class VersionService(
+  private val planVersionRepository: PlanVersionRepository,
+) {
+  @PersistenceContext
+  lateinit var entityManager: EntityManager
+
+  /**
+   * This function makes a copy of a PlanVersion object and all its descendent objects.
+   * New UUIDs are set on the copied objects and then persisted to the database.
+   */
+  @Transactional
+  fun createNewPlanVersion(planVersionUuid: UUID): PlanVersionEntity {
+    val newPlanVersionEntity: PlanVersionEntity
+
+    try {
+      newPlanVersionEntity = planVersionRepository.getWholePlanVersionByUuid(planVersionUuid)
+    } catch (e: NoResultException) {
+      throw NoResultException("A Plan Version couldn't be found for Plan Version UUID: $planVersionUuid")
+    }
+
+    entityManager.detach(newPlanVersionEntity)
+
+    newPlanVersionEntity.uuid = UUID.randomUUID()
+    newPlanVersionEntity.id = null
+    newPlanVersionEntity.agreementNote!!.id = null
+    newPlanVersionEntity.agreementNote!!.planVersion = newPlanVersionEntity
+
+    newPlanVersionEntity.planProgressNotes.forEach { planProgressNote ->
+      planProgressNote.id = null
+      planProgressNote.planVersion = newPlanVersionEntity
+    }
+
+    newPlanVersionEntity.goals.forEach { goal ->
+      entityManager.detach(goal)
+      goal.id = null
+      goal.uuid = UUID.randomUUID()
+      goal.planVersion = newPlanVersionEntity
+
+      val stepsList: List<StepEntity> = goal.steps.toList() // copy the list
+      stepsList.forEach { step ->
+        entityManager.detach(step)
+        step.id = null
+        step.uuid = UUID.randomUUID()
+        step.goal = goal
+      }
+      goal.steps = stepsList
+
+      val relatedAreasSet: MutableSet<AreaOfNeedEntity>? = goal.relatedAreasOfNeed?.toSet()?.toMutableSet()
+      goal.relatedAreasOfNeed = relatedAreasSet
+    }
+
+    planVersionRepository.save(newPlanVersionEntity)
+    entityManager.detach(newPlanVersionEntity)
+
+    val currentPlanVersion = planVersionRepository.findByUuid(planVersionUuid)
+    currentPlanVersion.version = currentPlanVersion.version.inc()
+    val updatedCurrentVersion = planVersionRepository.save(currentPlanVersion)
+
+    return updatedCurrentVersion
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionService.kt
@@ -28,7 +28,7 @@ class VersionService(
 
     try {
       newPlanVersionEntity = planVersionRepository.getWholePlanVersionByUuid(planVersionUuid)
-    } catch (e: NoResultException) {
+    } catch (_: NoResultException) {
       throw NoResultException("A Plan Version couldn't be found for Plan Version UUID: $planVersionUuid")
     }
 
@@ -37,7 +37,7 @@ class VersionService(
     newPlanVersionEntity.uuid = UUID.randomUUID()
     newPlanVersionEntity.id = null
     newPlanVersionEntity.agreementNote!!.id = null
-    newPlanVersionEntity.agreementNote!!.planVersion = newPlanVersionEntity
+    newPlanVersionEntity.agreementNote.planVersion = newPlanVersionEntity
 
     newPlanVersionEntity.planProgressNotes.forEach { planProgressNote ->
       planProgressNote.id = null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/PlanControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/PlanControllerTest.kt
@@ -212,7 +212,7 @@ class PlanControllerTest : IntegrationTestBase() {
           .expectBody<GoalEntity>()
           .returnResult().responseBody
 
-      val relatedAreasOfNeed: List<AreaOfNeedEntity>? = goalEntity?.relatedAreasOfNeed
+      val relatedAreasOfNeed: Set<AreaOfNeedEntity>? = goalEntity?.relatedAreasOfNeed
 
       assertThat(relatedAreasOfNeed?.size).isZero()
     }
@@ -235,7 +235,7 @@ class PlanControllerTest : IntegrationTestBase() {
           .expectBody<GoalEntity>()
           .returnResult().responseBody
 
-      val relatedAreasOfNeed: List<AreaOfNeedEntity>? = goalEntity?.relatedAreasOfNeed
+      val relatedAreasOfNeed: Set<AreaOfNeedEntity>? = goalEntity?.relatedAreasOfNeed
 
       assertThat(relatedAreasOfNeed?.size).isEqualTo(2)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
@@ -1,0 +1,121 @@
+package uk.gov.justice.digital.hmpps.sentenceplan.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestMethodOrder
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanProgressNotesRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.services.VersionService
+import java.util.UUID
+
+@DisplayName("Version Service Integration Tests")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class VersionServiceIntegrationTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var planProgressNoteRepository: PlanProgressNotesRepository
+
+  @Autowired
+  lateinit var versionService: VersionService
+
+  @Autowired
+  lateinit var planRepository: PlanRepository
+
+  @Autowired
+  lateinit var planVersionRepository: PlanVersionRepository
+
+  @Autowired
+  lateinit var goalRepository: GoalRepository
+
+  // from SQL scripts
+  val testPlanUuid = UUID.fromString("556db5c8-a1eb-4064-986b-0740d6a83c33")
+  val testPlanVersionUuid = UUID.fromString("9f2aaa46-e544-4bcd-8db6-fbe7842ddb64")
+  var newPlanVersionUuid: UUID = UUID.randomUUID()
+
+  @Test
+  @Order(1)
+  @DisplayName("Create new PlanVersion")
+  @WithMockUser(username = "UserId|Username")
+  @Sql(
+    scripts = [
+      "/db/test/oasys_assessment_pk_data.sql",
+      "/db/test/goals_data.sql",
+      "/db/test/related_area_of_need_data.sql",
+      "/db/test/step_data.sql",
+      "/db/test/plan_notes_data.sql",
+    ],
+    executionPhase = BEFORE_TEST_METHOD,
+  )
+  @Sql(
+    scripts = [
+      "/db/test/plan_notes_cleanup.sql",
+      "/db/test/step_cleanup.sql",
+      "/db/test/related_area_of_need_cleanup.sql",
+      "/db/test/goals_cleanup.sql",
+      "/db/test/oasys_assessment_pk_cleanup.sql",
+    ],
+    executionPhase = AFTER_TEST_METHOD,
+  )
+  fun `test new plan version has the same associations as previous version`() {
+    // a plan and a version are added via SQL scripts in annotation
+
+    // create a new version
+    val planVersionOne = versionService.createNewPlanVersion(testPlanVersionUuid)
+    newPlanVersionUuid = planVersionOne.uuid
+
+    // now check there are two versions
+    assertThat(planVersionRepository.findAll().size).isEqualTo(2)
+
+    // check that when fetched the plan references the version with ID 1
+    val planEntity = planRepository.findByUuid(testPlanUuid)
+    assertThat(planEntity.currentVersion!!.version).isEqualTo(1)
+
+    // check that the UUID of version 0 is now different to the original UUID
+    val planVersionZero = planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 0)
+    assertThat(planVersionZero.uuid).isNotEqualTo(testPlanVersionUuid)
+
+    // check that both versions reference the same plan
+    assertThat(planVersionZero.planId).isEqualTo(planVersionOne.planId)
+
+    // check that the latest version references the plan and that the previous version is null (reference is owned by PlanEntity)
+    assertThat(planVersionOne.plan!!).isNotNull
+    assertThat(planVersionZero.plan).isNull()
+
+    // check that each version has two goals
+    assertThat(planVersionZero.goals.size).isEqualTo(planVersionOne.goals.size)
+    assertThat(goalRepository.findAll()).hasSize(4)
+
+    // check that the first step in the first goal of each plan version have matching descriptions but different UUIDs
+    val planVersionZeroFirstGoal = goalRepository.findByUuidWithSteps(planVersionZero.goals.toList().get(0).uuid)
+    val planVersionOneFirstGoal = goalRepository.findByUuidWithSteps(planVersionOne.goals.toList().get(0).uuid)
+
+    assertThat(planVersionZeroFirstGoal.steps.get(0).description).isEqualTo(planVersionZeroFirstGoal.steps.get(0).description)
+    assertThat(planVersionZeroFirstGoal.steps.get(0).uuid).isNotEqualTo(planVersionOneFirstGoal.steps.get(0).uuid)
+
+    // check that each planVersion has its own PlanAgreementNote
+    assertThat(planVersionZero.agreementNote).isNotNull
+    assertThat(planVersionOne.agreementNote).isNotNull
+    assertThat(planVersionZero.agreementNote?.id).isNotEqualTo(planVersionOne.agreementNote?.id)
+
+    // fetch progress notes by plan version UUID and check that each planVersion has its own PlanProgressNotes
+    val planVersionZeroProgressNotes = planProgressNoteRepository.findByPlanVersionUuid(planVersionZero.uuid)
+    assertThat(planVersionZeroProgressNotes.size).isGreaterThan(0)
+
+    val planVersionOneProgressNotes = planProgressNoteRepository.findByPlanVersionUuid(planVersionOne.uuid)
+    assertThat(planVersionOneProgressNotes.size).isGreaterThan(0)
+
+    assertThat(planVersionZeroProgressNotes.get(0).id).isNotEqualTo(planVersionOneProgressNotes.get(0).id)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
@@ -99,10 +99,10 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
 
     // check that the first step in the first goal of each plan version have matching descriptions but different UUIDs
     val planVersionZeroFirstGoal = goalRepository.findByUuidWithSteps(planVersionZero.goals.toList()[0].uuid)
-    val planVersionOneFirstGoal = goalRepository.findByUuidWithSteps(planVersionOne.goals.toList().get(0).uuid)
+    val planVersionOneFirstGoal = goalRepository.findByUuidWithSteps(planVersionOne.goals.toList()[0].uuid)
 
-    assertThat(planVersionZeroFirstGoal.steps.get(0).description).isEqualTo(planVersionZeroFirstGoal.steps.get(0).description)
-    assertThat(planVersionZeroFirstGoal.steps.get(0).uuid).isNotEqualTo(planVersionOneFirstGoal.steps.get(0).uuid)
+    assertThat(planVersionZeroFirstGoal.steps[0].description).isEqualTo(planVersionZeroFirstGoal.steps[0].description)
+    assertThat(planVersionZeroFirstGoal.steps[0].uuid).isNotEqualTo(planVersionOneFirstGoal.steps[0].uuid)
 
     // check that each planVersion has its own PlanAgreementNote
     assertThat(planVersionZero.agreementNote).isNotNull
@@ -116,6 +116,6 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
     val planVersionOneProgressNotes = planProgressNoteRepository.findByPlanVersionUuid(planVersionOne.uuid)
     assertThat(planVersionOneProgressNotes.size).isGreaterThan(0)
 
-    assertThat(planVersionZeroProgressNotes.get(0).id).isNotEqualTo(planVersionOneProgressNotes.get(0).id)
+    assertThat(planVersionZeroProgressNotes[0].id).isNotEqualTo(planVersionOneProgressNotes[0].id)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
@@ -98,7 +98,7 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
     assertThat(goalRepository.findAll()).hasSize(4)
 
     // check that the first step in the first goal of each plan version have matching descriptions but different UUIDs
-    val planVersionZeroFirstGoal = goalRepository.findByUuidWithSteps(planVersionZero.goals.toList().get(0).uuid)
+    val planVersionZeroFirstGoal = goalRepository.findByUuidWithSteps(planVersionZero.goals.toList()[0].uuid)
     val planVersionOneFirstGoal = goalRepository.findByUuidWithSteps(planVersionOne.goals.toList().get(0).uuid)
 
     assertThat(planVersionZeroFirstGoal.steps.get(0).description).isEqualTo(planVersionZeroFirstGoal.steps.get(0).description)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
@@ -22,7 +22,6 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepStatus
@@ -34,11 +33,10 @@ import java.util.UUID
 class GoalServiceTest {
   private val goalRepository: GoalRepository = mockk()
   private val areaOfNeedRepository: AreaOfNeedRepository = mockk()
-  private val planVersionRepository: PlanVersionRepository = mockk()
   private val planRepository: PlanRepository = mockk()
   private val stepRepository: StepRepository = mockk()
 
-  private val goalService = GoalService(goalRepository, areaOfNeedRepository, planVersionRepository, stepRepository, planRepository)
+  private val goalService = GoalService(goalRepository, areaOfNeedRepository, stepRepository, planRepository)
   private val goalUuid = UUID.fromString("ef74ee4b-5a0b-481b-860f-19187260f2e7")
 
   private val goal: Goal = Goal(
@@ -75,7 +73,7 @@ class GoalServiceTest {
     planVersion = null,
     uuid = goalUuid,
     goalOrder = 1,
-    relatedAreasOfNeed = mockk<MutableList<AreaOfNeedEntity>>(),
+    relatedAreasOfNeed = mockk<MutableSet<AreaOfNeedEntity>>(),
   )
 
   private val steps = listOf(
@@ -94,8 +92,8 @@ class GoalServiceTest {
   private val incompleteSteps = steps + Step("This is a step with no actor", status = StepStatus.NOT_STARTED, actor = "")
 
   private val planEntity: PlanEntity = PlanEntity()
-  private val planVersionEntity: PlanVersionEntity = PlanVersionEntity(plan = planEntity)
-  private val planVersionEntityWithOneGoal: PlanVersionEntity = PlanVersionEntity(plan = planEntity, goals = goalSet)
+  private val planVersionEntity: PlanVersionEntity = PlanVersionEntity(plan = planEntity, planId = 0L)
+  private val planVersionEntityWithOneGoal: PlanVersionEntity = PlanVersionEntity(plan = planEntity, goals = goalSet, planId = 0L)
 
   @BeforeAll
   fun setup() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
@@ -34,8 +34,8 @@ class PlanServiceTest {
 
   @BeforeEach
   fun setup() {
-    planEntity = PlanEntity()
-    planVersionEntity = PlanVersionEntity(plan = planEntity)
+    planEntity = PlanEntity(id = 0L)
+    planVersionEntity = PlanVersionEntity(plan = planEntity, planId = 0L)
     planEntity.currentVersion = planVersionEntity
   }
 
@@ -148,7 +148,8 @@ class PlanServiceTest {
 
     @Test
     fun `should create and return a new plan`() {
-      every { planRepository.save(any()) } returnsArgument 0
+      every { planRepository.save(any()) } returns planEntity
+      every { planVersionRepository.save(any()) } returns planVersionEntity
 
       val result = planService.createPlan(PlanType.INITIAL)
 

--- a/src/test/resources/db/test/plan_notes_cleanup.sql
+++ b/src/test/resources/db/test/plan_notes_cleanup.sql
@@ -1,0 +1,2 @@
+DELETE FROM plan_agreement_notes;
+DELETE FROM plan_progress_notes;

--- a/src/test/resources/db/test/plan_notes_data.sql
+++ b/src/test/resources/db/test/plan_notes_data.sql
@@ -1,0 +1,10 @@
+INSERT INTO plan_agreement_notes (plan_version_id, optional_note, agreement_status, agreement_status_note, practitioner_name, person_name, created_date, created_by_id)
+SELECT plan_version.id, 'Optional note', 'DRAFT', 'Agreement status note', 'Practitioner name', 'Person name', now(), practitioner.id
+FROM plan_version, practitioner
+where plan_version.uuid = '9f2aaa46-e544-4bcd-8db6-fbe7842ddb64' and practitioner.external_id = 'test';
+
+insert into plan_progress_notes (plan_version_id, note, is_support_needed, is_support_needed_note, is_involved,
+                                 is_involved_note, person_name, practitioner_name, created_date, created_by_id)
+SELECT plan_version.id, 'Note', 'YES', 'Support needed note', TRUE, 'Is involved note', 'Person name', 'Practitioner name', now(), practitioner.id
+FROM plan_version, practitioner
+where plan_version.uuid = '9f2aaa46-e544-4bcd-8db6-fbe7842ddb64' and practitioner.external_id = 'test';

--- a/src/test/resources/db/test/related_area_of_need_data.sql
+++ b/src/test/resources/db/test/related_area_of_need_data.sql
@@ -1,0 +1,5 @@
+INSERT INTO related_area_of_need (goal_id, area_of_need_id)
+SELECT goal.id, area_of_need.id
+FROM goal, area_of_need
+WHERE goal.uuid = '31d7e986-4078-4f5c-af1d-115f9ba3722d'
+AND area_of_need.name = 'Health and wellbeing';


### PR DESCRIPTION
Lots of files have changed in this PR but they are all to support the work in `src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionService.kt`

The implementation of versioning here means that a Plan always has the same PlanVersion, and that PlanVersion is where all changes happen.

When an event occurs which requires a new version, these things happen:

1. a copy of the PlanVersion is made
2. the value of the primary PlanVersion.version field is incremented
3. the change to the PlanVersion is made (this part is to be implemented in the next story)

This means that the plan.current_plan_version_id will never change and the planversion.uuid of the "current" plan version  will never change.

The change to how a Goal is deleted is because something about the Cascade between it and the PlanVersion means that the Goal would never be deleted correctly, even when performed by `repository.deleteById`.