### PR TITLE
Fix create endpoint, adjust PlanVersionResponse object

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/config/JpaAuditConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/config/JpaAuditConfig.kt
@@ -18,9 +18,19 @@ class JpaAuditConfig(private val practitionerRepository: PractitionerRepository)
   fun auditorProvider(): AuditorAware<PractitionerEntity> = AuditorAware<PractitionerEntity> {
     var practitionerEntity: PractitionerEntity
 
-    val usernameParts = SecurityContextHolder.getContext().authentication.name.split('|')
-    val externalId: String = usernameParts[0]
-    val username: String = usernameParts[1]
+    val authenticationName = SecurityContextHolder.getContext().authentication.name
+
+    val usernameParts = authenticationName.split('|')
+    val externalId: String
+    val username: String
+
+    if (usernameParts.size != 2) {
+      externalId = "SYSTEM"
+      username = usernameParts[0]
+    } else {
+      externalId = usernameParts[0]
+      username = usernameParts[1]
+    }
 
     try {
       practitionerEntity = practitionerRepository.findByExternalId(externalId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/CoordinatorController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/CoordinatorController.kt
@@ -137,7 +137,7 @@ class CoordinatorController(
      *  - Handle any exceptions or edge cases (i.e plan not found, cloning failures).
      */
     return PlanVersionResponse(
-      planUuid = UUID.randomUUID(),
+      planId = UUID.randomUUID(),
       planVersion = 0,
     )
   }
@@ -180,7 +180,7 @@ class CoordinatorController(
      *  - Handle any exceptions or edge cases (i,e plan not found, locking failures)
      */
     return PlanVersionResponse(
-      planUuid = planUuid,
+      planId = planUuid,
       planVersion = 10,
     )
   }
@@ -223,7 +223,7 @@ class CoordinatorController(
      *  - Handle any exceptions or edge cases (i,e, plan not found, locking failures)
      */
     return PlanVersionResponse(
-      planUuid = planUuid,
+      planId = planUuid,
       planVersion = 15,
     )
   }
@@ -267,7 +267,7 @@ class CoordinatorController(
      *  - Handle any exceptions or edge cases (i.e plan or version not found, invalid sign type, countersigning failures))
      */
     return PlanVersionResponse(
-      planUuid = planUuid,
+      planId = planUuid,
       planVersion = body.sentencePlanVersion,
     )
   }
@@ -311,7 +311,7 @@ class CoordinatorController(
      *  - Handle any exceptions or edge cases (i.e plan or version not found, invalid state for rollback, rollback failures)
      */
     return PlanVersionResponse(
-      planUuid = planUuid,
+      planId = planUuid,
       planVersion = body.sentencePlanVersion,
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/response/PlanVersionResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/response/PlanVersionResponse.kt
@@ -4,14 +4,13 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
 import java.util.UUID
 
 data class PlanVersionResponse(
-  val planUuid: UUID,
+  val planId: UUID,
   val planVersion: Long,
 ) {
   companion object {
     fun from(planEntity: PlanEntity): PlanVersionResponse {
       return PlanVersionResponse(
-        planUuid = planEntity.uuid,
-        // Set proper version later
+        planId = planEntity.uuid,
         planVersion = 0L,
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/CoordinatorControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/CoordinatorControllerTest.kt
@@ -48,7 +48,7 @@ class CoordinatorControllerTest : IntegrationTestBase() {
         .expectBody<PlanVersionResponse>()
         .returnResult().apply {
           assertThat(responseBody?.planVersion).isEqualTo(0L)
-          assertThat(responseBody?.planUuid).isNotNull
+          assertThat(responseBody?.planId).isNotNull
         }
     }
   }


### PR DESCRIPTION
- Fix create endpoint by allowing JPA auditor to handle s2s calls
- Updated PlanVersionResponse object to use `planId` rather than `planUuid`