### PR TITLE
Update naming schema for coordinator endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/CoordinatorController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/CoordinatorController.kt
@@ -142,14 +142,14 @@ class CoordinatorController(
     )
   }
 
-  @PostMapping("/{planUuid}/lock")
+  @PostMapping("/{planUuid}/sign")
   @Operation(
-    description = "Locks the specified sentence plan, updating its status to 'LOCKED' and returning the latest version of the plan.",
+    description = "Signs the specified sentence plan, updating its status to 'AWAITING_COUNTERSIGN' and returning the latest version of the plan.",
     tags = ["Integrations"],
   )
   @ApiResponses(
     value = [
-      ApiResponse(responseCode = "200", description = "Plan locked successfully"),
+      ApiResponse(responseCode = "200", description = "Plan signed successfully"),
       ApiResponse(
         responseCode = "404",
         description = "Plan not found",
@@ -157,7 +157,7 @@ class CoordinatorController(
       ),
       ApiResponse(
         responseCode = "409",
-        description = "Plan could not be locked. See details in error message.",
+        description = "Plan could not be signed. See details in error message.",
         content = arrayOf(Content(schema = Schema(implementation = ErrorResponse::class))),
       ),
       ApiResponse(
@@ -167,16 +167,16 @@ class CoordinatorController(
       ),
     ],
   )
-  fun lockPlan(
+  fun signPlan(
     @PathVariable planUuid: UUID,
   ): PlanVersionResponse {
     /**
      * TODO: Implement logic to lock the sentence plan identified by 'planUuid'
      *  - Retrieve the plan using 'planUuid'
-     *  - Update the plan's status to 'LOCKED' (?is this AWAIITNG_COUNTERSIGN?).
+     *  - Update the plan's status to `AWAIITNG_COUNTERSIGN`
      *    - When doing this, make sure you DO NOT update the plan version number
      *  - Create a new plan version with countersigning_status as UNSIGNED
-     *  - Save the changes and ensure the locked version number is returned
+     *  - Save the changes and ensure the AWAIITNG_COUNTERSIGN version number is returned
      *  - Handle any exceptions or edge cases (i,e plan not found, locking failures)
      */
     return PlanVersionResponse(
@@ -185,14 +185,14 @@ class CoordinatorController(
     )
   }
 
-  @PostMapping("/{planUuid}/lock-incomplete")
+  @PostMapping("/{planUuid}/lock")
   @Operation(
     description = "Locks the specified sentence plan, updating its status to 'LOCKED_INCOMPLETE' and returning the latest version of the plan.",
     tags = ["Integrations"],
   )
   @ApiResponses(
     value = [
-      ApiResponse(responseCode = "200", description = "Plan locked successfully"),
+      ApiResponse(responseCode = "200", description = "Plan locked (incomplete) successfully"),
       ApiResponse(
         responseCode = "404",
         description = "Plan not found",
@@ -210,7 +210,7 @@ class CoordinatorController(
       ),
     ],
   )
-  fun lockIncompletePlan(
+  fun lockPlan(
     @PathVariable planUuid: UUID,
   ): PlanVersionResponse {
     /**
@@ -219,7 +219,7 @@ class CoordinatorController(
      *  - Update the plan's status to 'LOCKED_INCOMPLETE'.
      *    - When doing this, make sure you DO NOT update the plan version number
      *  - Create a new plan version with countersigning_status as UNSIGNED (?are we sure this is the correct behaviour?)
-     *  - Save the changes and ensure the locked version number is returned
+     *  - Save the changes and ensure the LOCKED_INCOMPLETE version number is returned
      *  - Handle any exceptions or edge cases (i,e, plan not found, locking failures)
      */
     return PlanVersionResponse(


### PR DESCRIPTION
- rename `/lock` to `/sign`
- rename `/lock-incomplete` to `/lock`