### PR TITLE
SP2-768 Adds versioning when PlanVersion is updated

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
@@ -152,7 +152,7 @@ class GoalService(
 
   @Transactional
   fun deleteGoalByUuid(goalUuid: UUID): Int {
-    versionService.conditionallyCreateNewPlanVersion(goalRepository.findByUuid(goalUuid)?.planVersion)
+    goalRepository.findByUuid(goalUuid)?.let { versionService.conditionallyCreateNewPlanVersion(it.planVersion) }
     return goalRepository.deleteByUuid(goalUuid)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
@@ -63,6 +63,7 @@ class PlanService(
     return planEntity
   }
 
+  @Transactional
   fun agreeLatestPlanVersion(planUuid: UUID, agreement: Agreement): PlanVersionEntity {
     var planVersion: PlanVersionEntity
     try {
@@ -84,8 +85,7 @@ class PlanService(
     return planVersion
   }
 
-  @Transactional
-  fun addPlanAgreementNote(planVersionEntity: PlanVersionEntity, agreement: Agreement) {
+  private fun addPlanAgreementNote(planVersionEntity: PlanVersionEntity, agreement: Agreement) {
     val currentPlanVersion = versionService.conditionallyCreateNewPlanVersion(planVersionEntity)
 
     val planAgreementNote = PlanAgreementNoteEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
@@ -84,9 +84,12 @@ class PlanService(
     return planVersion
   }
 
+  @Transactional
   fun addPlanAgreementNote(planVersionEntity: PlanVersionEntity, agreement: Agreement) {
+    val currentPlanVersion = versionService.conditionallyCreateNewPlanVersion(planVersionEntity)
+
     val planAgreementNote = PlanAgreementNoteEntity(
-      planVersion = planVersionEntity,
+      planVersion = currentPlanVersion,
       agreementStatus = agreement.agreementStatus,
       agreementStatusNote = agreement.agreementStatusNote,
       optionalNote = agreement.optionalNote,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionService.kt
@@ -9,6 +9,8 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.AreaOfNeedEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 @Service
@@ -95,7 +97,11 @@ class VersionService(
       return planVersion
     }
 
-    return createNewPlanVersion(planVersion.uuid)
+    return if (LocalDateTime.now().truncatedTo(ChronoUnit.DAYS).isAfter(planVersion.updatedDate)) {
+      createNewPlanVersion(planVersion.uuid)
+    } else {
+      planVersion
+    }
   }
 
   /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionService.kt
@@ -72,6 +72,8 @@ class VersionService(
     currentPlanVersion.version = currentPlanVersion.version.inc()
     val updatedCurrentVersion = planVersionRepository.save(currentPlanVersion)
 
+    entityManager.flush()
+
     return updatedCurrentVersion
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
@@ -11,10 +11,14 @@ import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD
 import org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD
+import uk.gov.justice.digital.hmpps.sentenceplan.data.Goal
+import uk.gov.justice.digital.hmpps.sentenceplan.data.Step
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalStatus
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanProgressNotesRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepStatus
 import uk.gov.justice.digital.hmpps.sentenceplan.services.GoalService
 import uk.gov.justice.digital.hmpps.sentenceplan.services.VersionService
 import java.util.UUID
@@ -120,5 +124,82 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
     assertThat(planVersionOneProgressNotes.size).isGreaterThan(0)
 
     assertThat(planVersionZeroProgressNotes[0].id).isNotEqualTo(planVersionOneProgressNotes[0].id)
+  }
+
+  // ------------------------------------------------
+
+  @Test
+  @DisplayName("Adding Goals creates new PlanVersions")
+  @WithMockUser(username = "UserId|Username")
+  @Sql(scripts = [ "/db/test/oasys_assessment_pk_data.sql" ], executionPhase = BEFORE_TEST_METHOD)
+  @Sql(scripts = [ "/db/test/goals_cleanup.sql", "/db/test/oasys_assessment_pk_cleanup.sql" ], executionPhase = AFTER_TEST_METHOD)
+  fun `test adding goals creates new plan versions correctly`() {
+    // a plan and a version are added via SQL scripts in annotation
+
+    assertThat(planVersionRepository.findAll().size).isEqualTo(1)
+    assertThat(planVersionRepository.findAll().first().goals.size).isEqualTo(0)
+
+    val goal = Goal(title = "Version testing", areaOfNeed = "Accommodation", status = GoalStatus.FUTURE)
+
+    goalService.createNewGoal(testPlanUuid, goal)
+
+    assertThat(planVersionRepository.findAll().size).isEqualTo(2)
+
+    assertThat(planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 0).goals.size).isEqualTo(0)
+    assertThat(planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 1).goals.size).isEqualTo(1)
+
+    assertThat(planVersionRepository.findByUuid(testPlanVersionUuid).goals.size).isEqualTo(1)
+
+    // Now add another goal and check the numbers are correct.
+    // We should end with the following version:goal counts:
+    // 0:0
+    // 1:1
+    // 2:2
+    println("=========================================================")
+    val secondGoal = Goal(title = "More version testing", areaOfNeed = "Accommodation", status = GoalStatus.FUTURE)
+
+    goalService.createNewGoal(testPlanUuid, secondGoal)
+
+    assertThat(planVersionRepository.findAll().size).isEqualTo(3)
+
+    assertThat(planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 0).goals.size).isEqualTo(0)
+    assertThat(planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 1).goals.size).isEqualTo(1)
+    assertThat(planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 2).goals.size).isEqualTo(2)
+
+    assertThat(planVersionRepository.findByUuid(testPlanVersionUuid).goals.size).isEqualTo(2)
+  }
+
+  // ------------------------------------------------
+
+  @Test
+  @DisplayName("Adding Steps creates new PlanVersions")
+  @WithMockUser(username = "UserId|Username")
+  @Sql(scripts = [ "/db/test/oasys_assessment_pk_data.sql", "/db/test/goals_data.sql" ], executionPhase = BEFORE_TEST_METHOD)
+  @Sql(scripts = [ "/db/test/step_cleanup.sql", "/db/test/goals_cleanup.sql", "/db/test/oasys_assessment_pk_cleanup.sql" ], executionPhase = AFTER_TEST_METHOD)
+  fun `test adding steps creates new goals and plan versions correctly`() {
+    // a plan and a version are added via SQL scripts in annotation
+
+    // establish that we have one PlanEntity and that the initial PlanVersionEntity has two goals
+    assertThat(planVersionRepository.findAll().size).isEqualTo(1)
+    assertThat(planVersionRepository.findAll().first().goals.size).isEqualTo(2)
+
+    // add a step to the goal
+    val step = Step(description = "Step description", status = StepStatus.NOT_STARTED, actor = "Step actor")
+    val steps: List<Step> = listOf(step)
+    goalService.addStepsToGoal(UUID.fromString("31d7e986-4078-4f5c-af1d-115f9ba3722d"), steps)
+
+    // we should now have two versions, original and once made when adding steps
+    assertThat(planVersionRepository.findAll().size).isEqualTo(2)
+
+    assertThat(planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 0).goals.size).isEqualTo(2)
+    assertThat(planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 1).goals.size).isEqualTo(2)
+
+    val planVersionZero = planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 0)
+    val wholePlanVersionZero = planVersionRepository.getWholePlanVersionByUuid(planVersionZero.uuid)
+    assertThat(wholePlanVersionZero.goals.first().steps.size).isEqualTo(0)
+
+    val planVersionOne = planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 1)
+    val wholePlanVersionOne = planVersionRepository.getWholePlanVersionByUuid(planVersionOne.uuid)
+    assertThat(wholePlanVersionOne.goals.first().steps.size).isEqualTo(1)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
@@ -79,7 +79,7 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
 
     // create a new version
     val planVersion = planVersionRepository.findByUuid(testPlanVersionUuid)
-    val planVersionOne = versionService.conditionallyCreateNewPlanVersion(planVersion)
+    val planVersionOne = versionService.alwaysCreateNewPlanVersion(planVersion)
     newPlanVersionUuid = planVersionOne.uuid
 
     // now check there are two versions
@@ -149,27 +149,7 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
     assertThat(planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 1).goals.size).isEqualTo(1)
 
     assertThat(planVersionRepository.findByUuid(testPlanVersionUuid).goals.size).isEqualTo(1)
-
-    // Now add another goal and check the numbers are correct.
-    // We should end with the following version:goal counts:
-    // 0:0
-    // 1:1
-    // 2:2
-    println("=========================================================")
-    val secondGoal = Goal(title = "More version testing", areaOfNeed = "Accommodation", status = GoalStatus.FUTURE)
-
-    goalService.createNewGoal(testPlanUuid, secondGoal)
-
-    assertThat(planVersionRepository.findAll().size).isEqualTo(3)
-
-    assertThat(planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 0).goals.size).isEqualTo(0)
-    assertThat(planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 1).goals.size).isEqualTo(1)
-    assertThat(planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 2).goals.size).isEqualTo(2)
-
-    assertThat(planVersionRepository.findByUuid(testPlanVersionUuid).goals.size).isEqualTo(2)
   }
-
-  // ------------------------------------------------
 
   @Test
   @DisplayName("Adding Steps creates new PlanVersions")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
@@ -230,9 +230,10 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
       "Practitioner Name",
       "person Name",
     )
-    val agreedPlanVersion = planService.agreeLatestPlanVersion(testPlanUuid, agreement)
 
-    // we should now have two planversions, original and once made when agreeing the Plan
+    planService.agreeLatestPlanVersion(testPlanUuid, agreement)
+
+    // we should now have two PlanVersions, original and once made when agreeing the Plan
     assertThat(planVersionRepository.findAll().size).isEqualTo(2)
 
     val planVersionZero = planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 0)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
@@ -11,15 +11,18 @@ import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD
 import org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD
+import uk.gov.justice.digital.hmpps.sentenceplan.data.Agreement
 import uk.gov.justice.digital.hmpps.sentenceplan.data.Goal
 import uk.gov.justice.digital.hmpps.sentenceplan.data.Step
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalStatus
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanAgreementStatus
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanProgressNotesRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepStatus
 import uk.gov.justice.digital.hmpps.sentenceplan.services.GoalService
+import uk.gov.justice.digital.hmpps.sentenceplan.services.PlanService
 import uk.gov.justice.digital.hmpps.sentenceplan.services.VersionService
 import java.util.UUID
 
@@ -46,9 +49,12 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
   @Autowired
   lateinit var goalService: GoalService
 
+  @Autowired
+  lateinit var planService: PlanService
+
   // from SQL scripts
-  val testPlanUuid = UUID.fromString("556db5c8-a1eb-4064-986b-0740d6a83c33")
-  val testPlanVersionUuid = UUID.fromString("9f2aaa46-e544-4bcd-8db6-fbe7842ddb64")
+  val testPlanUuid = UUID.fromString("556db5c8-a1eb-4064-986b-0740d6a83c33")!!
+  val testPlanVersionUuid = UUID.fromString("9f2aaa46-e544-4bcd-8db6-fbe7842ddb64")!!
   var newPlanVersionUuid: UUID = UUID.randomUUID()
 
   @Test
@@ -126,8 +132,6 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
     assertThat(planVersionZeroProgressNotes[0].id).isNotEqualTo(planVersionOneProgressNotes[0].id)
   }
 
-  // ------------------------------------------------
-
   @Test
   @DisplayName("Adding Goals creates new PlanVersions")
   @WithMockUser(username = "UserId|Username")
@@ -181,5 +185,61 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
     val planVersionOne = planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 1)
     val wholePlanVersionOne = planVersionRepository.getWholePlanVersionByUuid(planVersionOne.uuid)
     assertThat(wholePlanVersionOne.goals.first().steps.size).isEqualTo(1)
+  }
+
+  @Test
+  @DisplayName("Adding Steps to Goal with Steps creates new PlanVersions")
+  @WithMockUser(username = "UserId|Username")
+  @Sql(scripts = [ "/db/test/oasys_assessment_pk_data.sql", "/db/test/goals_data.sql", "/db/test/step_data.sql" ], executionPhase = BEFORE_TEST_METHOD)
+  @Sql(scripts = [ "/db/test/step_cleanup.sql", "/db/test/goals_cleanup.sql", "/db/test/oasys_assessment_pk_cleanup.sql" ], executionPhase = AFTER_TEST_METHOD)
+  fun `test adding steps to a goal with steps creates new goals and plan versions correctly`() {
+    // a plan and a version are added via SQL scripts in annotation
+
+    // add a step to the goal
+    val step = Step(description = "New step description", status = StepStatus.NOT_STARTED, actor = "Step actor")
+    val steps: List<Step> = listOf(step)
+    goalService.addStepsToGoal(UUID.fromString("31d7e986-4078-4f5c-af1d-115f9ba3722d"), steps)
+
+    // we should now have two planversions, original and once made when adding the new step
+    assertThat(planVersionRepository.findAll().size).isEqualTo(2)
+
+    assertThat(planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 0).goals.size).isEqualTo(2)
+    assertThat(planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 1).goals.size).isEqualTo(2)
+
+    val planVersionZero = planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 0)
+    val wholePlanVersionZero = planVersionRepository.getWholePlanVersionByUuid(planVersionZero.uuid)
+    assertThat(wholePlanVersionZero.goals.first().steps.size).isEqualTo(1)
+
+    val planVersionOne = planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 1)
+    val wholePlanVersionOne = planVersionRepository.getWholePlanVersionByUuid(planVersionOne.uuid)
+    assertThat(wholePlanVersionOne.goals.first().steps.size).isEqualTo(2)
+  }
+
+  @Test
+  @DisplayName("Agreeing a Plan creates new PlanVersions")
+  @WithMockUser(username = "UserId|Username")
+  @Sql(scripts = [ "/db/test/oasys_assessment_pk_data.sql", "/db/test/goals_data.sql", "/db/test/step_data.sql" ], executionPhase = BEFORE_TEST_METHOD)
+  @Sql(scripts = [ "/db/test/step_cleanup.sql", "/db/test/goals_cleanup.sql", "/db/test/oasys_assessment_pk_cleanup.sql" ], executionPhase = AFTER_TEST_METHOD)
+  fun `agreeing a plan creates new goals and plan versions correctly`() {
+    // a plan and a version are added via SQL scripts in annotation
+
+    val agreement = Agreement(
+      PlanAgreementStatus.AGREED,
+      "Status note",
+      "Optional note",
+      "Practitioner Name",
+      "person Name",
+    )
+    val agreedPlanVersion = planService.agreeLatestPlanVersion(testPlanUuid, agreement)
+
+    // we should now have two planversions, original and once made when agreeing the Plan
+    assertThat(planVersionRepository.findAll().size).isEqualTo(2)
+
+    val planVersionZero = planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 0)
+    val planVersionOne = planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 1)
+
+    assertThat(planVersionZero.agreementNote).isNull()
+    assertThat(planVersionOne.agreementNote).isNotNull
+    assertThat(planVersionOne.agreementNote?.agreementStatus).isEqualTo(PlanAgreementStatus.AGREED)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
@@ -201,6 +201,7 @@ class PlanServiceTest {
       planVersionEntity.agreementStatus = PlanAgreementStatus.AGREED
 
       every { planRepository.findByUuid(any()) } returns planEntity
+      every { versionService.conditionallyCreateNewPlanVersion(any()) } returns agreedNewPlanVersionEntity
 
       val exception = assertThrows(ConflictException::class.java) {
         planService.agreeLatestPlanVersion(UUID.fromString("559a2111-832c-4652-a99f-eec9e570640f"), agreement)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
@@ -181,6 +181,7 @@ class PlanServiceTest {
       every { planRepository.findByUuid(any()) } returns planEntity
       every { planVersionRepository.save(any()) } returns planVersionEntity
       every { planAgreementNoteRepository.save(any()) } returns any()
+      every { versionService.conditionallyCreateNewPlanVersion(any()) } returns newPlanVersionEntity
 
       val result = planService.agreeLatestPlanVersion(UUID.randomUUID(), agreement)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
@@ -33,17 +33,22 @@ class PlanServiceTest {
   private val planRepository: PlanRepository = mockk()
   private val planVersionRepository: PlanVersionRepository = mockk()
   private val planAgreementNoteRepository: PlanAgreementNoteRepository = mockk()
-  private val versionService: VersionService = mockk()
+  private val versionService: VersionService = mockk<VersionService>(relaxed = true)
   private val planService = PlanService(planRepository, planVersionRepository, planAgreementNoteRepository, versionService)
   private lateinit var planEntity: PlanEntity
   private lateinit var planVersionEntity: PlanVersionEntity
   private lateinit var newPlanVersionEntity: PlanVersionEntity
+  private lateinit var agreedNewPlanVersionEntity: PlanVersionEntity
 
   @BeforeEach
   fun setup() {
     planEntity = PlanEntity(id = 0L)
-    planVersionEntity = PlanVersionEntity(plan = planEntity, planId = 0L)
-    newPlanVersionEntity = PlanVersionEntity(plan = planEntity, planId = 1L)
+    planVersionEntity = PlanVersionEntity(id = 0, plan = planEntity, planId = 0L, version = 0)
+    newPlanVersionEntity = PlanVersionEntity(id = 1, plan = planEntity, planId = 0L, version = 1)
+    agreedNewPlanVersionEntity = PlanVersionEntity(
+      id = 1, plan = planEntity, planId = 0L, version = 1,
+      agreementStatus = PlanAgreementStatus.AGREED,
+    )
     planEntity.currentVersion = planVersionEntity
   }
 
@@ -179,14 +184,16 @@ class PlanServiceTest {
     @Test
     fun `should agree plan version`() {
       every { planRepository.findByUuid(any()) } returns planEntity
-      every { planVersionRepository.save(any()) } returns planVersionEntity
+      every { planVersionRepository.save(planVersionEntity) } returns planVersionEntity
+      every { planVersionRepository.save(newPlanVersionEntity) } returns agreedNewPlanVersionEntity
       every { planAgreementNoteRepository.save(any()) } returns any()
-      every { versionService.conditionallyCreateNewPlanVersion(any()) } returns newPlanVersionEntity
+      every { versionService.conditionallyCreateNewPlanVersion(planVersionEntity) } returns newPlanVersionEntity
 
       val result = planService.agreeLatestPlanVersion(UUID.randomUUID(), agreement)
 
-      verify(exactly = 1) { planVersionRepository.save(withArg { assertEquals(result, it) }) }
       verify(exactly = 1) { planAgreementNoteRepository.save(any()) }
+      assertThat(result.version).isEqualTo(newPlanVersionEntity.version)
+      assertThat(result.agreementStatus).isEqualTo(agreement.agreementStatus)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionServiceTest.kt
@@ -53,4 +53,13 @@ class VersionServiceTest {
 
     assertThat(returnedPlanVersion.version).isEqualTo(newPlanVersionEntity.version)
   }
+
+  @Test
+  fun `should make a new version if the last updated date was last year`() {
+    planVersionEntity.updatedDate = LocalDateTime.now().minusYears(1)
+
+    val returnedPlanVersion = versionService.conditionallyCreateNewPlanVersion(planVersionEntity)
+
+    assertThat(returnedPlanVersion.version).isEqualTo(newPlanVersionEntity.version)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionServiceTest.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.sentenceplan.services
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
+import java.time.LocalDateTime
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class VersionServiceTest {
+
+  private lateinit var planEntity: PlanEntity
+  private lateinit var planVersionEntity: PlanVersionEntity
+  private lateinit var newPlanVersionEntity: PlanVersionEntity
+
+  private val planVersionRepository: PlanVersionRepository = mockk()
+
+  private var versionService = spyk(VersionService(planVersionRepository), recordPrivateCalls = true)
+
+  @BeforeEach
+  fun setup() {
+    planEntity = PlanEntity(id = 0L)
+    planVersionEntity = PlanVersionEntity(plan = planEntity, id = 0, planId = 0L, version = 0)
+    newPlanVersionEntity = PlanVersionEntity(plan = planEntity, id = 1, planId = 0L, version = 1)
+    planEntity.currentVersion = planVersionEntity
+
+    every { planVersionRepository.getWholePlanVersionByUuid(any()) } returns planVersionEntity
+    every { planVersionRepository.findByUuid(any()) } returns planVersionEntity
+    every { planVersionRepository.save(any()) } returns newPlanVersionEntity
+
+    versionService.entityManager = mockk<EntityManager>(relaxed = true)
+  }
+
+  @Test
+  fun `should not make a new version if the last updated date was today`() {
+    val returnedPlanVersion = versionService.conditionallyCreateNewPlanVersion(planVersionEntity)
+
+    assertThat(returnedPlanVersion.version).isEqualTo(0)
+  }
+
+  @Test
+  fun `should make a new version if the last updated date was yesterday`() {
+    planVersionEntity.updatedDate = LocalDateTime.now().minusDays(1)
+
+    val returnedPlanVersion = versionService.conditionallyCreateNewPlanVersion(planVersionEntity)
+
+    assertThat(returnedPlanVersion.version).isEqualTo(1)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionServiceTest.kt
@@ -51,6 +51,6 @@ class VersionServiceTest {
 
     val returnedPlanVersion = versionService.conditionallyCreateNewPlanVersion(planVersionEntity)
 
-    assertThat(returnedPlanVersion.version).isEqualTo(1)
+    assertThat(returnedPlanVersion.version).isEqualTo(newPlanVersionEntity.version)
   }
 }

--- a/src/test/resources/db/test/oasys_assessment_pk_data.sql
+++ b/src/test/resources/db/test/oasys_assessment_pk_data.sql
@@ -3,13 +3,13 @@ INSERT INTO practitioner(external_id, username) VALUES ('test', 'test user');
 
 -- Insert into plan
 INSERT INTO plan(uuid, published_state, created_date, created_by_id, last_updated_date, last_updated_by_id)
-SELECT '556db5c8-a1eb-4064-986b-0740d6a83c33', 'UNPUBLISHED', now() , practitioner.id, now(), practitioner.id
+SELECT '556db5c8-a1eb-4064-986b-0740d6a83c33', 'UNPUBLISHED', now() - interval '1 day', practitioner.id, now() - interval '1 day', practitioner.id
 FROM practitioner
 WHERE external_id = 'test';
 
 -- Insert into plan_version
 INSERT INTO plan_version(uuid, plan_id, plan_type, version, countersigning_status, agreement_status, created_date, created_by_id, last_updated_date, last_updated_by_id, read_only)
-SELECT '9f2aaa46-e544-4bcd-8db6-fbe7842ddb64', plan.id, 'INITIAL', 0, 'UNSIGNED', 'DRAFT', now(), practitioner.id, now(), practitioner.id, false
+SELECT '9f2aaa46-e544-4bcd-8db6-fbe7842ddb64', plan.id, 'INITIAL', 0, 'UNSIGNED', 'DRAFT', now() - interval '1 day', practitioner.id, now() - interval '1 day', practitioner.id, false
 from plan, practitioner
 where plan.uuid = '556db5c8-a1eb-4064-986b-0740d6a83c33' and practitioner.external_id = 'test';
 


### PR DESCRIPTION
This PR contains 3 main things:

1. It only creates a new plan version if the last updated date was a day or more before the date of the current change
2. It adds calls to create a new plan version in all the service classes which modify the object tree of a plan version
3. It updates existing tests and adds new integration tests for different types of behaviour