### PR TITLE
SP2-884 change add steps endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/GoalController.kt
@@ -62,7 +62,7 @@ class GoalController(private val service: GoalService) {
     @PathVariable goalUuid: UUID,
     @RequestBody steps: List<Step>,
   ): List<StepEntity> {
-    return service.addStepsToGoal(goalUuid, steps)
+    return service.addStepsToGoal(goalUuid, Goal(steps = steps))
   }
 
   @GetMapping("/{goalUuid}/steps")
@@ -78,9 +78,9 @@ class GoalController(private val service: GoalService) {
   @ResponseStatus(HttpStatus.OK)
   fun updateStep(
     @PathVariable goalUuid: UUID,
-    @RequestBody steps: List<Step>,
+    @RequestBody goal: Goal,
   ): List<StepEntity>? {
-    return service.addStepsToGoal(goalUuid, steps, true)
+    return service.addStepsToGoal(goalUuid, goal, true)
   }
 
   @PostMapping("/order")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/data/Goal.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/data/Goal.kt
@@ -9,4 +9,5 @@ data class Goal(
   val relatedAreasOfNeed: List<String> = emptyList(),
   val status: GoalStatus? = null,
   val note: String? = null,
+  val steps: List<Step> = emptyList(),
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
@@ -537,7 +537,7 @@ class GoalControllerTest : IntegrationTestBase() {
       val steps: List<StepEntity>? = webTestClient.put().uri("/goals/$goalWithNoStepsUuid/steps")
         .header("Content-Type", "application/json")
         .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
-        .bodyValue(stepList)
+        .bodyValue(Goal(steps = stepList))
         .exchange()
         .expectStatus().isOk
         .expectBody<List<StepEntity>>()
@@ -557,7 +557,7 @@ class GoalControllerTest : IntegrationTestBase() {
       val steps: List<StepEntity>? = webTestClient.put().uri("/goals/$goalWithOneStepUuid/steps")
         .header("Content-Type", "application/json")
         .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_RISK_INTEGRATIONS_RO")))
-        .bodyValue(stepList)
+        .bodyValue(Goal(steps = stepList))
         .exchange()
         .expectStatus().isOk
         .expectBody<List<StepEntity>>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
@@ -174,7 +174,7 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
     // add a step to the goal
     val step = Step(description = "Step description", status = StepStatus.NOT_STARTED, actor = "Step actor")
     val steps: List<Step> = listOf(step)
-    goalService.addStepsToGoal(UUID.fromString("31d7e986-4078-4f5c-af1d-115f9ba3722d"), steps)
+    goalService.addStepsToGoal(UUID.fromString("31d7e986-4078-4f5c-af1d-115f9ba3722d"), Goal(steps = steps))
 
     // we should now have two versions, original and once made when adding steps
     assertThat(planVersionRepository.findAll().size).isEqualTo(2)
@@ -202,7 +202,7 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
     // add a step to the goal
     val step = Step(description = "New step description", status = StepStatus.NOT_STARTED, actor = "Step actor")
     val steps: List<Step> = listOf(step)
-    goalService.addStepsToGoal(UUID.fromString("31d7e986-4078-4f5c-af1d-115f9ba3722d"), steps)
+    goalService.addStepsToGoal(UUID.fromString("31d7e986-4078-4f5c-af1d-115f9ba3722d"), Goal(steps = steps))
 
     // we should now have two planversions, original and once made when adding the new step
     assertThat(planVersionRepository.findAll().size).isEqualTo(2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
@@ -220,7 +220,7 @@ class GoalServiceTest {
       every { goalRepository.save(capture(goalSlot)) } answers { goalSlot.captured }
       every { versionService.conditionallyCreateNewPlanVersion(any()) } returns newPlanVersionEntity
 
-      val stepsList = goalService.addStepsToGoal(goalUuid, steps)
+      val stepsList = goalService.addStepsToGoal(goalUuid, Goal(steps = steps))
 
       assertThat(stepsList.size).isEqualTo(2)
 
@@ -363,7 +363,7 @@ class GoalServiceTest {
       every { versionService.conditionallyCreateNewPlanVersion(any()) } returns newPlanVersionEntity
 
       val exception = assertThrows<Exception> {
-        goalService.addStepsToGoal(UUID.randomUUID(), steps, true)
+        goalService.addStepsToGoal(UUID.randomUUID(), Goal(steps = steps), true)
       }
 
       assertThat(exception.message).startsWith("This Goal was not found:")
@@ -375,7 +375,7 @@ class GoalServiceTest {
       every { versionService.conditionallyCreateNewPlanVersion(any()) } returns newPlanVersionEntity
 
       val exception = assertThrows<IllegalArgumentException> {
-        goalService.addStepsToGoal(UUID.randomUUID(), emptyList(), true)
+        goalService.addStepsToGoal(UUID.randomUUID(), Goal(steps = emptyList()), true)
       }
 
       assertThat(exception.message).startsWith("At least one Step must be provided")
@@ -387,7 +387,7 @@ class GoalServiceTest {
       every { versionService.conditionallyCreateNewPlanVersion(any()) } returns newPlanVersionEntity
 
       val exception = assertThrows<IllegalArgumentException> {
-        goalService.addStepsToGoal(UUID.randomUUID(), incompleteSteps, true)
+        goalService.addStepsToGoal(UUID.randomUUID(), Goal(steps = incompleteSteps), true)
       }
 
       assertThat(exception.message).startsWith("All Steps must contain all the required information")
@@ -401,7 +401,7 @@ class GoalServiceTest {
       every { stepRepository.deleteAll(any()) } returns Unit
       every { versionService.conditionallyCreateNewPlanVersion(any()) } returns newPlanVersionEntity
 
-      val stepsList = goalService.addStepsToGoal(goalUuid, steps, true)
+      val stepsList = goalService.addStepsToGoal(goalUuid, Goal(steps = steps), true)
 
       assertThat(stepsList.size).isEqualTo(2)
 
@@ -440,7 +440,7 @@ class GoalServiceTest {
       every { stepRepository.deleteAll(any()) } returns Unit
       every { versionService.conditionallyCreateNewPlanVersion(any()) } returns newPlanVersionEntity
 
-      val stepsList = goalService.addStepsToGoal(goalUuid, steps, true)
+      val stepsList = goalService.addStepsToGoal(goalUuid, Goal(steps = steps), true)
 
       assertThat(stepsList.size).isEqualTo(2)
 


### PR DESCRIPTION
This is the counterpart PR to https://github.com/ministryofjustice/hmpps-sentence-plan-ui/pull/180 which makes the two Steps endpoints require a Goal which contains those steps so that we can additionally send a note without substantial rework and without relying on no future changes in versioning behaviour.