### PR TITLE
Fix add note and update steps

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
@@ -453,5 +453,31 @@ class GoalServiceTest {
       assertThat(stepsList.last().goal?.uuid).isEqualTo(goalUuid)
       assertThat(stepsList.last().description).isEqualTo("description 2")
     }
+
+    @Test
+    fun `update steps with no steps and a note saves the note`() {
+      val goalSlot = slot<GoalEntity>()
+
+      val goalEntityWithNoSteps = GoalEntity(
+        title = "Mock Goal",
+        areaOfNeed = mockk<AreaOfNeedEntity>(),
+        planVersion = null,
+        uuid = goalUuid,
+        goalOrder = 1,
+      )
+
+      val noteToAdd = "This is a new note"
+
+      every { goalRepository.findByUuid(goalUuid) } returns goalEntityNoSteps
+      every { goalRepository.save(capture(goalSlot)) } answers { goalSlot.captured }
+      every { stepRepository.deleteAll(any()) } returns Unit
+      every { versionService.conditionallyCreateNewPlanVersion(any()) } returns newPlanVersionEntity
+
+      val stepsList = goalService.addStepsToGoal(goalUuid, Goal(note = noteToAdd), true)
+
+      assertThat(stepsList.size).isEqualTo(0)
+      assertThat(goalSlot.captured.notes.size).isEqualTo(1)
+      assertThat(goalSlot.captured.notes.first().note).isEqualTo(noteToAdd)
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
@@ -378,7 +378,7 @@ class GoalServiceTest {
         goalService.addStepsToGoal(UUID.randomUUID(), Goal(steps = emptyList()), true)
       }
 
-      assertThat(exception.message).startsWith("At least one Step must be provided")
+      assertThat(exception.message).startsWith("A Step or Note must be provided")
     }
 
     @Test


### PR DESCRIPTION
Allows update-goal to continue to use saveAllSteps even when there are steps but there is a note.