### PR TITLE
First pass at supporting viewing old PlanVersions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/PlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/PlanController.kt
@@ -40,6 +40,19 @@ class PlanController(
     }
   }
 
+  @GetMapping("/{planUuid}/{planVersionNumber}")
+  @ResponseStatus(HttpStatus.OK)
+  fun getPlan(
+    @PathVariable planUuid: UUID,
+    @PathVariable planVersionNumber: Int,
+  ): PlanVersionEntity {
+    try {
+      return planService.getPlanVersionByPlanUuidAndPlanVersion(planUuid, planVersionNumber)
+    } catch (e: EmptyResultDataAccessException) {
+      throw NoResourceFoundException(HttpMethod.GET, "Could not find a plan with ID: $planUuid and version number: $planVersionNumber")
+    }
+  }
+
   @GetMapping("/{planUuid}/goals")
   @ResponseStatus(HttpStatus.OK)
   fun getPlanGoals(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanVersionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanVersionEntity.kt
@@ -168,7 +168,7 @@ interface PlanVersionRepository : JpaRepository<PlanVersionEntity, Long> {
       "where p.uuid = :planUuid and plan_version.version = :versionNumber",
     nativeQuery = true,
   )
-  fun findByPlanUuidAndVersion(planUuid: UUID, versionNumber: Int): PlanVersionEntity
+  fun findByPlanUuidAndVersionNumber(planUuid: UUID, versionNumber: Int): PlanVersionEntity
 
   @Query(
     """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
@@ -38,6 +38,10 @@ class PlanService(
     return planEntity.currentVersion!!
   }
 
+  fun getPlanVersionByPlanUuidAndPlanVersion(planUuid: UUID, planVersion: Int): PlanVersionEntity {
+    return planVersionRepository.getVersionByUuidAndVersion(planUuid, planVersion)
+  }
+
   fun rollbackVersion(planUuid: UUID, versionNumber: Int): PlanVersionEntity {
     val version = planVersionRepository.getVersionByUuidAndVersion(planUuid, versionNumber)
     version.status = CountersigningStatus.ROLLED_BACK
@@ -207,7 +211,7 @@ class PlanService(
 
     versionService.alwaysCreateNewPlanVersion(planVersion)
 
-    val signedPlan = planVersionRepository.findByPlanUuidAndVersion(planUuid, planVersion.version)
+    val signedPlan = planVersionRepository.findByPlanUuidAndVersionNumber(planUuid, planVersion.version)
 
     when (signRequest.signType) {
       SignType.SELF -> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/CoordinatorControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/CoordinatorControllerTest.kt
@@ -238,7 +238,7 @@ class CoordinatorControllerTest : IntegrationTestBase() {
           assertThat(responseBody?.planVersion).isEqualTo(beforeVersion.toLong())
         }
 
-      val afterStatus = planVersionRepository.findByPlanUuidAndVersion(planUuid, beforeVersion).status
+      val afterStatus = planVersionRepository.findByPlanUuidAndVersionNumber(planUuid, beforeVersion).status
       val newPlanVersion = planRepository.getPlanByUuid(planUuid).currentVersion
 
       assertThat(afterStatus).isNotEqualTo(beforeVersionStatus)
@@ -300,7 +300,7 @@ class CoordinatorControllerTest : IntegrationTestBase() {
           assertThat(responseBody?.planVersion).isEqualTo(beforeVersion.toLong())
         }
 
-      val afterStatus = planVersionRepository.findByPlanUuidAndVersion(planUuid, beforeVersion).status
+      val afterStatus = planVersionRepository.findByPlanUuidAndVersionNumber(planUuid, beforeVersion).status
 
       assertThat(afterStatus).isNotEqualTo(beforeVersionStatus)
       assertThat(afterStatus).isEqualTo(CountersigningStatus.ROLLED_BACK)
@@ -363,7 +363,7 @@ class CoordinatorControllerTest : IntegrationTestBase() {
           assertThat(responseBody?.planVersion).isEqualTo(beforeVersion.toLong())
         }
 
-      val afterStatus = planVersionRepository.findByPlanUuidAndVersion(planUuid, beforeVersion).status
+      val afterStatus = planVersionRepository.findByPlanUuidAndVersionNumber(planUuid, beforeVersion).status
 
       assertThat(afterStatus).isNotEqualTo(beforeVersionStatus)
       assertThat(afterStatus).isEqualTo(CountersigningStatus.AWAITING_DOUBLE_COUNTERSIGN)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
@@ -100,7 +100,7 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
     assertThat(planEntity.currentVersion!!.version).isEqualTo(1)
 
     // check that the UUID of version 0 is now different to the original UUID
-    val planVersionZero = planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 0)
+    val planVersionZero = planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 0)
     assertThat(planVersionZero.uuid).isNotEqualTo(testPlanVersionUuid)
 
     // check that both versions reference the same plan
@@ -153,8 +153,8 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
 
     assertThat(planVersionRepository.findAll().size).isEqualTo(2)
 
-    assertThat(planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 0).goals.size).isEqualTo(0)
-    assertThat(planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 1).goals.size).isEqualTo(1)
+    assertThat(planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 0).goals.size).isEqualTo(0)
+    assertThat(planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 1).goals.size).isEqualTo(1)
 
     assertThat(planVersionRepository.findByUuid(testPlanVersionUuid).goals.size).isEqualTo(1)
   }
@@ -179,14 +179,14 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
     // we should now have two versions, original and once made when adding steps
     assertThat(planVersionRepository.findAll().size).isEqualTo(2)
 
-    assertThat(planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 0).goals.size).isEqualTo(2)
-    assertThat(planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 1).goals.size).isEqualTo(2)
+    assertThat(planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 0).goals.size).isEqualTo(2)
+    assertThat(planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 1).goals.size).isEqualTo(2)
 
-    val planVersionZero = planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 0)
+    val planVersionZero = planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 0)
     val wholePlanVersionZero = planVersionRepository.getWholePlanVersionByUuid(planVersionZero.uuid)
     assertThat(wholePlanVersionZero.goals.first().steps.size).isEqualTo(0)
 
-    val planVersionOne = planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 1)
+    val planVersionOne = planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 1)
     val wholePlanVersionOne = planVersionRepository.getWholePlanVersionByUuid(planVersionOne.uuid)
     assertThat(wholePlanVersionOne.goals.first().steps.size).isEqualTo(1)
   }
@@ -207,14 +207,14 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
     // we should now have two planversions, original and once made when adding the new step
     assertThat(planVersionRepository.findAll().size).isEqualTo(2)
 
-    assertThat(planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 0).goals.size).isEqualTo(2)
-    assertThat(planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 1).goals.size).isEqualTo(2)
+    assertThat(planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 0).goals.size).isEqualTo(2)
+    assertThat(planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 1).goals.size).isEqualTo(2)
 
-    val planVersionZero = planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 0)
+    val planVersionZero = planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 0)
     val wholePlanVersionZero = planVersionRepository.getWholePlanVersionByUuid(planVersionZero.uuid)
     assertThat(wholePlanVersionZero.goals.first().steps.size).isEqualTo(1)
 
-    val planVersionOne = planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 1)
+    val planVersionOne = planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 1)
     val wholePlanVersionOne = planVersionRepository.getWholePlanVersionByUuid(planVersionOne.uuid)
     assertThat(wholePlanVersionOne.goals.first().steps.size).isEqualTo(2)
   }
@@ -240,8 +240,8 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
     // we should now have two PlanVersions, original and once made when agreeing the Plan
     assertThat(planVersionRepository.findAll().size).isEqualTo(2)
 
-    val planVersionZero = planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 0)
-    val planVersionOne = planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 1)
+    val planVersionZero = planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 0)
+    val planVersionOne = planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 1)
 
     assertThat(planVersionZero.agreementNote).isNull()
     assertThat(planVersionOne.agreementNote).isNotNull
@@ -269,8 +269,8 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
     // we should now have two plan versions, original and one made before signing the Plan
     assertThat(planVersionRepository.findAll().size).isEqualTo(2)
 
-    val planVersionZero = planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 0)
-    val planVersionOne = planVersionRepository.findByPlanUuidAndVersion(testPlanUuid, 1)
+    val planVersionZero = planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 0)
+    val planVersionOne = planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 1)
 
     assertThat(planVersionZero.status).isEqualTo(CountersigningStatus.SELF_SIGNED)
     assertThat(planVersionOne.status).isEqualTo(CountersigningStatus.UNSIGNED)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
@@ -244,7 +244,7 @@ class PlanServiceTest {
     fun `should mark plan as self-signed`() {
       every { planRepository.findByUuid(any()) } returns planEntity.apply { currentVersion?.agreementStatus = PlanAgreementStatus.AGREED }
       every { planVersionRepository.save(any()) } returnsArgument 0
-      every { planVersionRepository.findByPlanUuidAndVersion(any(), any()) } returns newPlanVersionEntity
+      every { planVersionRepository.findByPlanUuidAndVersionNumber(any(), any()) } returns newPlanVersionEntity
       every { versionService.alwaysCreateNewPlanVersion(any()) } returns newPlanVersionEntity
 
       val signRequest = SignRequest(
@@ -261,7 +261,7 @@ class PlanServiceTest {
     fun `should mark plan as awaiting-countersign`() {
       every { planRepository.findByUuid(any()) } returns planEntity.apply { currentVersion?.agreementStatus = PlanAgreementStatus.AGREED }
       every { planVersionRepository.save(any()) } returnsArgument 0
-      every { planVersionRepository.findByPlanUuidAndVersion(any(), any()) } returns newPlanVersionEntity
+      every { planVersionRepository.findByPlanUuidAndVersionNumber(any(), any()) } returns newPlanVersionEntity
       every { versionService.conditionallyCreateNewPlanVersion(any()) } returns newPlanVersionEntity
 
       val signRequest = SignRequest(


### PR DESCRIPTION
This adds a new endpoint for explicitly receiving a plan UUID and the plan version number we want to view.