### PR TITLE
Disable nDelius and ARNS API stub in dev and test

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -13,7 +13,6 @@ generic-service:
     HMPPS_AUTH_BASE_URL: https://sign-in-dev.hmpps.service.justice.gov.uk
     ARNS_API_BASE_URL: https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk
     DELIUS_API_BASE_URL: https://sentence-plan-and-delius-dev.hmpps.service.justice.gov.uk
-    USE_STUB: true
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -13,7 +13,6 @@ generic-service:
     HMPPS_AUTH_BASE_URL: https://sign-in-dev.hmpps.service.justice.gov.uk
     ARNS_API_BASE_URL: https://assess-risks-and-needs-test.hmpps.service.justice.gov.uk
     DELIUS_API_BASE_URL: https://sentence-plan-and-delius-dev.hmpps.service.justice.gov.uk
-    USE_STUB: true
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts


### PR DESCRIPTION
- Note the ARNS API is no longer used, and can likely be removed. It was originally used for RoSH scores.