### PR TITLE
Specifies use of commons-io 2.14.0 to avoid a transitive vulnerability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,9 @@ dependencies {
     implementation("org.bouncycastle:bcprov-jdk18on:1.79") {
       because("1.77 has CVEs")
     }
+    implementation("commons-io:commons-io:2.14.0") {
+      because("2.11 has CVEs")
+    }
   }
   implementation("org.springframework.cloud:spring-cloud-dependencies:2023.0.3")
   implementation("com.vladmihalcea:hibernate-types-60:2.21.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
       because("1.77 has CVEs")
     }
     implementation("commons-io:commons-io:2.14.0") {
-      because("2.11 has CVEs")
+      because("2.11 has CVEs and is included via commons-upload 1.5 via spring-cloud-openfeign 4.1.3")
     }
   }
   implementation("org.springframework.cloud:spring-cloud-dependencies:2023.0.3")


### PR DESCRIPTION
Tested locally before and after change with trivy. Post change report was clean.