### PR TITLE
Updates version of uk.gov.justice.hmpps.gradle-spring-boot to 6.1.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.springframework.boot.gradle.tasks.run.BootRun
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.0.8"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.1.0"
   kotlin("plugin.spring") version "2.0.21"
   kotlin("plugin.jpa") version "2.0.21"
   kotlin("jvm") version "2.0.21"


### PR DESCRIPTION
This resolves this CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-29025

Until recently updating to 6.1.0 caused an issue with accessing /v3/api-docs but this is now resolved in the underlying libraries.