### PR TITLE
SP2-836 Make last updated field represent sub-entities

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanVersionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanVersionEntity.kt
@@ -135,6 +135,7 @@ class PlanVersionEntity(
   @Formula("GREATEST(last_updated_date, (SELECT MAX(g.last_updated_date) FROM goal g WHERE g.plan_version_id = id))")
   var mostRecentUpdateDate: LocalDateTime? = null,
 
+  // this query retrieves the username directly because Formula can only retrieve scalar values, not objects.
   @Formula(
     """
     (select p.username FROM practitioner p

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/PlanControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/PlanControllerTest.kt
@@ -41,8 +41,8 @@ class PlanControllerTest : IntegrationTestBase() {
 
   @Nested
   @DisplayName("getPlan")
-  @Sql(scripts = [ "/db/test/plan_data.sql", "/db/test/goals_data.sql" ], executionPhase = BEFORE_TEST_CLASS)
-  @Sql(scripts = [ "/db/test/goals_cleanup.sql", "/db/test/plan_cleanup.sql" ], executionPhase = AFTER_TEST_CLASS)
+//  @Sql(scripts = [ "/db/test/plan_data.sql", "/db/test/goals_data.sql" ], executionPhase = BEFORE_TEST_CLASS)
+//  @Sql(scripts = [ "/db/test/goals_cleanup.sql", "/db/test/plan_cleanup.sql" ], executionPhase = AFTER_TEST_CLASS)
   inner class GetPlan {
     @Test
     fun `should return OK when getting plan by existing UUID `() {
@@ -54,6 +54,10 @@ class PlanControllerTest : IntegrationTestBase() {
         .returnResult().responseBody
 
       assertThat(planVersionEntity?.goals?.size).isEqualTo(2)
+      assertThat(planVersionEntity?.mostRecentUpdateDate).isNotNull()
+      assertThat(planVersionEntity?.mostRecentUpdateDate).isAfter(planVersionEntity?.updatedDate)
+      assertThat(planVersionEntity?.mostRecentUpdateByName).isNotNull()
+      assertThat(planVersionEntity?.mostRecentUpdateByName).isEqualTo("test user")
     }
 
     @Test
@@ -87,6 +91,9 @@ class PlanControllerTest : IntegrationTestBase() {
       assertThat(goalsMap?.get("now")?.first()?.title).isEqualTo("Goal For Now Title")
       assertThat(goalsMap?.get("future")?.first()?.title).isEqualTo("Goal For Future Title")
     }
+
+    // TODO  make sure there is a test where goal.updatedDate is later than plan.lastUpdatedDate (ideally harmonise these names!)
+    // and then check the value of mostRecentUpdateDate
 
     @Test
     fun `should return not found when getting goals by non-existent plan UUID`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/PlanControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/PlanControllerTest.kt
@@ -41,8 +41,8 @@ class PlanControllerTest : IntegrationTestBase() {
 
   @Nested
   @DisplayName("getPlan")
-//  @Sql(scripts = [ "/db/test/plan_data.sql", "/db/test/goals_data.sql" ], executionPhase = BEFORE_TEST_CLASS)
-//  @Sql(scripts = [ "/db/test/goals_cleanup.sql", "/db/test/plan_cleanup.sql" ], executionPhase = AFTER_TEST_CLASS)
+  @Sql(scripts = [ "/db/test/plan_data.sql", "/db/test/goals_data.sql" ], executionPhase = BEFORE_TEST_CLASS)
+  @Sql(scripts = [ "/db/test/goals_cleanup.sql", "/db/test/plan_cleanup.sql" ], executionPhase = AFTER_TEST_CLASS)
   inner class GetPlan {
     @Test
     fun `should return OK when getting plan by existing UUID `() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/PlanControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/PlanControllerTest.kt
@@ -92,9 +92,6 @@ class PlanControllerTest : IntegrationTestBase() {
       assertThat(goalsMap?.get("future")?.first()?.title).isEqualTo("Goal For Future Title")
     }
 
-    // TODO  make sure there is a test where goal.updatedDate is later than plan.lastUpdatedDate (ideally harmonise these names!)
-    // and then check the value of mostRecentUpdateDate
-
     @Test
     fun `should return not found when getting goals by non-existent plan UUID`() {
       val randomPlanUuid = UUID.randomUUID()


### PR DESCRIPTION
This PR adds two new fields to the PlanVersionEntity class which are:

1) the timestamp that this object or any of its child Goals were last modified
2) the username of the practitioner that made that change

This is done by using the `@Formula` annotation to calculate the value of those fields dynamically. `@Formula` fields are automatically Transient so there's no need to mark them as such.

As part of this I needed to convert an existing native SQL query to use JPQL so that it understands not to map those fields from the ResultSet - any future queries in the PlanVersionRepository which return a PlanVersionEntity will also need to use JPQL rather than native queries for this reason.