### PR TITLE
SP2-1124 JPA consistency

### DIFF
--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ down: ## Stops and removes all containers in the project.
 	docker compose ${LOCAL_COMPOSE_FILES} down
 
 build-api: ## Builds a production image of the API.
-	docker-compose ${DEV_COMPOSE_FILES} build api
+	docker-compose build api
 
 dev-up: ## Starts/restarts the API in a development container. A remote debugger can be attached on port 5005.
 	docker compose ${DEV_COMPOSE_FILES} down api

--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ down: ## Stops and removes all containers in the project.
 	docker compose ${LOCAL_COMPOSE_FILES} down
 
 build-api: ## Builds a production image of the API.
-	docker-compose build api
+	docker-compose ${DEV_COMPOSE_FILES} build api
 
 dev-up: ## Starts/restarts the API in a development container. A remote debugger can be attached on port 5005.
 	docker compose ${DEV_COMPOSE_FILES} down api

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/CoordinatorController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/CoordinatorController.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.SignRequest
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.SoftDeletePlanVersionsRequest
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.response.GetPlanResponse
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.response.PlanVersionResponse
+import uk.gov.justice.digital.hmpps.sentenceplan.exceptions.NotFoundException
 import uk.gov.justice.digital.hmpps.sentenceplan.services.PlanService
 import java.util.UUID
 
@@ -133,7 +134,7 @@ class CoordinatorController(
     try {
       return planService.signPlan(planUuid, signRequest)
         .run(PlanVersionResponse::from)
-    } catch (_: EmptyResultDataAccessException) {
+    } catch (_: NotFoundException) {
       throw NoResourceFoundException(HttpMethod.GET, "Could not find a plan with ID: $planUuid")
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/CoordinatorController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/CoordinatorController.kt
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import jakarta.validation.Valid
-import org.springframework.dao.EmptyResultDataAccessException
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
@@ -96,7 +95,7 @@ class CoordinatorController(
     try {
       return planService.getPlanVersionByPlanUuid(planUuid)
         .run(GetPlanResponse::from)
-    } catch (_: EmptyResultDataAccessException) {
+    } catch (_: NotFoundException) {
       throw NoResourceFoundException(HttpMethod.GET, "Could not find a plan with ID: $planUuid")
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/PlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/PlanController.kt
@@ -38,7 +38,7 @@ class PlanController(
   ): PlanVersionEntity {
     try {
       return planService.getPlanVersionByPlanUuid(planUuid)
-    } catch (e: EmptyResultDataAccessException) {
+    } catch (e: NotFoundException) {
       throw NoResourceFoundException(HttpMethod.GET, "Could not find a plan with ID: $planUuid")
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/PlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/PlanController.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.controller
 
-import org.springframework.dao.EmptyResultDataAccessException
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
@@ -50,7 +49,7 @@ class PlanController(
   ): List<Note> {
     try {
       return planService.getPlanAndGoalNotes(planUuid)
-    } catch (e: EmptyResultDataAccessException) {
+    } catch (e: NotFoundException) {
       throw NoResourceFoundException(HttpMethod.GET, "Could not find a plan with ID: $planUuid")
     }
   }
@@ -77,7 +76,7 @@ class PlanController(
       val plan = planService.getPlanVersionByPlanUuid(planUuid)
       val (now, future) = plan.goals.partition { it.targetDate != null }
       return mapOf("now" to now, "future" to future)
-    } catch (e: EmptyResultDataAccessException) {
+    } catch (e: NotFoundException) {
       throw NoResourceFoundException(HttpMethod.GET, "Could not retrieve the latest version of plan with ID: $planUuid")
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/PlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/PlanController.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.sentenceplan.data.Note
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.exceptions.ConflictException
+import uk.gov.justice.digital.hmpps.sentenceplan.exceptions.NotFoundException
 import uk.gov.justice.digital.hmpps.sentenceplan.services.GoalService
 import uk.gov.justice.digital.hmpps.sentenceplan.services.PlanService
 import java.util.UUID
@@ -62,8 +63,8 @@ class PlanController(
   ): PlanVersionEntity {
     try {
       return planService.getPlanVersionByPlanUuidAndPlanVersion(planUuid, planVersionNumber)
-    } catch (e: EmptyResultDataAccessException) {
-      throw NoResourceFoundException(HttpMethod.GET, "Could not find a plan with ID: $planUuid and version number: $planVersionNumber")
+    } catch (e: NotFoundException) {
+      throw NoResourceFoundException(HttpMethod.GET, e.message)
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/PlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/PlanController.kt
@@ -64,7 +64,7 @@ class PlanController(
     try {
       return planService.getPlanVersionByPlanUuidAndPlanVersion(planUuid, planVersionNumber)
     } catch (e: NotFoundException) {
-      throw NoResourceFoundException(HttpMethod.GET, e.message)
+      throw NoResourceFoundException(HttpMethod.GET, e.message!!)
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/PlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/PlanController.kt
@@ -37,7 +37,7 @@ class PlanController(
   ): PlanVersionEntity {
     try {
       return planService.getPlanVersionByPlanUuid(planUuid)
-    } catch (e: NotFoundException) {
+    } catch (_: NotFoundException) {
       throw NoResourceFoundException(HttpMethod.GET, "Could not find a plan with ID: $planUuid")
     }
   }
@@ -49,7 +49,7 @@ class PlanController(
   ): List<Note> {
     try {
       return planService.getPlanAndGoalNotes(planUuid)
-    } catch (e: NotFoundException) {
+    } catch (_: NotFoundException) {
       throw NoResourceFoundException(HttpMethod.GET, "Could not find a plan with ID: $planUuid")
     }
   }
@@ -76,7 +76,7 @@ class PlanController(
       val plan = planService.getPlanVersionByPlanUuid(planUuid)
       val (now, future) = plan.goals.partition { it.targetDate != null }
       return mapOf("now" to now, "future" to future)
-    } catch (e: NotFoundException) {
+    } catch (_: NotFoundException) {
       throw NoResourceFoundException(HttpMethod.GET, "Could not retrieve the latest version of plan with ID: $planUuid")
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/PlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/PlanController.kt
@@ -99,7 +99,7 @@ class PlanController(
   ): PlanVersionEntity {
     try {
       return planService.agreeLatestPlanVersion(planUuid, agreement)
-    } catch (e: EmptyResultDataAccessException) {
+    } catch (e: NotFoundException) {
       throw ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, e.message)
     } catch (e: ConflictException) {
       throw ResponseStatusException(HttpStatus.CONFLICT, e.message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanEntity.kt
@@ -140,7 +140,7 @@ enum class PublishState {
 }
 
 @Repository
-interface PlanEntityRepository :
+interface PlanRepository :
   JpaRepository<PlanEntity, Long>,
   PlanEntityExceptionHandlingRepository {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanEntity.kt
@@ -7,7 +7,6 @@ import jakarta.persistence.ColumnResult
 import jakarta.persistence.ConstructorResult
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
-import jakarta.persistence.EntityManager
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
@@ -16,9 +15,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.NamedNativeQuery
-import jakarta.persistence.NoResultException
 import jakarta.persistence.OneToOne
-import jakarta.persistence.PersistenceContext
 import jakarta.persistence.SqlResultSetMapping
 import jakarta.persistence.Table
 import org.springframework.data.annotation.CreatedBy
@@ -30,7 +27,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.sentenceplan.data.Note
-import uk.gov.justice.digital.hmpps.sentenceplan.exceptions.NotFoundException
+import uk.gov.justice.digital.hmpps.sentenceplan.repository.PlanEntityExceptionHandlingRepository
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -150,28 +147,4 @@ interface PlanEntityRepository :
   // this uses the NoteMapping annotated on the PlanEntity class above
   @Query(nativeQuery = true)
   fun getPlanAndGoalNotes(planUuid: UUID): List<Note>
-}
-
-interface PlanEntityExceptionHandlingRepository {
-  fun getByUuid(planUuid: UUID): PlanEntity
-}
-
-@Repository
-class PlanEntityExceptionHandlingRepositoryImpl(
-  @PersistenceContext private val entityManager: EntityManager,
-) : PlanEntityExceptionHandlingRepository {
-  override fun getByUuid(planUuid: UUID): PlanEntity = try {
-    entityManager.createQuery(
-      """
-        SELECT p
-        FROM PlanEntity p
-        WHERE p.uuid = :planUuid
-        """,
-      PlanEntity::class.java,
-    )
-      .setParameter("planUuid", planUuid)
-      .singleResult
-  } catch (e: NoResultException) {
-    throw NotFoundException("Plan not found for id $planUuid")
-  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/repository/PlanEntityExceptionHandlingRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/repository/PlanEntityExceptionHandlingRepository.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.sentenceplan.repository
+
+import jakarta.persistence.EntityManager
+import jakarta.persistence.NoResultException
+import jakarta.persistence.PersistenceContext
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
+import uk.gov.justice.digital.hmpps.sentenceplan.exceptions.NotFoundException
+import java.util.UUID
+
+interface PlanEntityExceptionHandlingRepository {
+  fun getByUuid(planUuid: UUID): PlanEntity
+}
+
+@Repository
+class PlanEntityExceptionHandlingRepositoryImpl(
+  @PersistenceContext private val entityManager: EntityManager,
+) : PlanEntityExceptionHandlingRepository {
+  override fun getByUuid(planUuid: UUID): PlanEntity = try {
+    entityManager.createQuery(
+      """
+        SELECT p
+        FROM PlanEntity p
+        WHERE p.uuid = :planUuid
+        """,
+      PlanEntity::class.java,
+    )
+      .setParameter("planUuid", planUuid)
+      .singleResult
+  } catch (e: NoResultException) {
+    throw NotFoundException("Plan not found for id $planUuid")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/repository/PlanVersionExceptionHandlingRepositoryImpl.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/repository/PlanVersionExceptionHandlingRepositoryImpl.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.sentenceplan.repository
+
+import jakarta.persistence.EntityManager
+import jakarta.persistence.NoResultException
+import jakarta.persistence.PersistenceContext
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
+import uk.gov.justice.digital.hmpps.sentenceplan.exceptions.NotFoundException
+import java.util.UUID
+
+/**
+ * This class is for methods that need to handle exceptions in the repository layer.
+ * All JPA methods should be in the [uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository] interface.
+ */
+interface PlanVersionExceptionHandlingRepository {
+  fun getVersionByUuidAndVersion(planUuid: UUID, versionNumber: Int): PlanVersionEntity
+}
+
+@Repository
+class PlanVersionExceptionHandlingRepositoryImpl(
+  @PersistenceContext private val entityManager: EntityManager,
+) : PlanVersionExceptionHandlingRepository {
+  override fun getVersionByUuidAndVersion(planUuid: UUID, versionNumber: Int): PlanVersionEntity {
+    try {
+      return entityManager.createQuery(
+        """
+    SELECT pv
+    FROM PlanVersion pv
+    WHERE pv.planId = (
+        SELECT p.id
+        FROM PlanEntity p
+        WHERE p.uuid = :planUuid
+    ) AND pv.version = :versionNumber
+    """,
+      )
+        .setParameter("planUuid", planUuid)
+        .setParameter("versionNumber", versionNumber)
+        .singleResult as PlanVersionEntity
+    } catch (e: NoResultException) {
+      throw NotFoundException("Plan version $versionNumber not found for Plan uuid $planUuid")
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
@@ -39,11 +39,7 @@ class GoalService(
   fun createNewGoal(planUuid: UUID, goal: Goal): GoalEntity {
     val planVersionEntity: PlanVersionEntity
 
-    try {
-      planVersionEntity = planRepository.getByUuid(planUuid).currentVersion!!
-    } catch (e: NotFoundException) {
-      throw Exception("A Plan with this UUID was not found: $planUuid")
-    }
+    planVersionEntity = planRepository.getByUuid(planUuid).currentVersion!!
 
     require(goal.areaOfNeed != null && goal.title != null)
 
@@ -52,7 +48,7 @@ class GoalService(
     try {
       areaOfNeedEntity = areaOfNeedRepository.findByNameIgnoreCase(goal.areaOfNeed)
     } catch (e: EmptyResultDataAccessException) {
-      throw Exception("An Area of Need with this name was not found: ${goal.areaOfNeed}")
+      throw NotFoundException("An Area of Need with this name was not found: ${goal.areaOfNeed}")
     }
 
     val relatedAreasOfNeedEntity = getAreasOfNeedByNames(goal.relatedAreasOfNeed)
@@ -80,12 +76,12 @@ class GoalService(
     var relatedAreasOfNeedList: List<AreaOfNeedEntity> = emptyList()
     if (areasOfNeed.isNotEmpty()) {
       relatedAreasOfNeedList = areaOfNeedRepository.findAllByNames(areasOfNeed)
-        ?: throw Exception("One or more of the Related Areas of Need was not found: $areasOfNeed")
+        ?: throw NotFoundException("One or more of the Related Areas of Need was not found: $areasOfNeed")
 
       // findAllByNames doesn't throw an exception if a subset of goal.relatedAreasOfNeed is not found, so we
       // do a hard check on the count of returned items here
       if (areasOfNeed.size != relatedAreasOfNeedList.size) {
-        throw Exception("One or more of the Related Areas of Need was not found")
+        throw NotFoundException("One or more of the Related Areas of Need was not found")
       }
     }
     return relatedAreasOfNeedList
@@ -100,7 +96,7 @@ class GoalService(
   @Transactional
   fun replaceGoalByUuid(goalUuid: UUID, goal: Goal): GoalEntity {
     val goalEntity = goalRepository.findByUuid(goalUuid)
-      ?: throw Exception("This Goal was not found: $goalUuid")
+      ?: throw NotFoundException("This Goal was not found: $goalUuid")
 
     validateGoalFields(goal)
 
@@ -122,7 +118,7 @@ class GoalService(
   @Transactional
   fun addStepsToGoal(goalUuid: UUID, goal: Goal, replaceExistingSteps: Boolean = false): List<StepEntity> {
     var goalEntity: GoalEntity = goalRepository.findByUuid(goalUuid)
-      ?: throw Exception("This Goal was not found: $goalUuid")
+      ?: throw NotFoundException("This Goal was not found: $goalUuid")
 
     if (goal.steps.isEmpty() && goal.note.isNullOrEmpty()) {
       throw IllegalArgumentException("A Step or Note must be provided")
@@ -226,7 +222,7 @@ class GoalService(
       try {
         planVersionEntity = planVersionRepository.findByUuid(goalEntity.planVersion!!.uuid)
       } catch (e: EmptyResultDataAccessException) {
-        throw Exception("A Plan with this UUID was not found: $goalEntity.planVersion!!.uuid")
+        throw NotFoundException("A Plan with this UUID was not found: $goalEntity.planVersion!!.uuid")
       }
 
       val highestGoalOrder = planVersionEntity.goals.maxByOrNull { g -> g.goalOrder }?.goalOrder ?: 0

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalNoteEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalNoteType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalStatus
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntityRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
@@ -29,7 +29,7 @@ class GoalService(
   private val goalRepository: GoalRepository,
   private val areaOfNeedRepository: AreaOfNeedRepository,
   private val stepRepository: StepRepository,
-  private val planRepository: PlanEntityRepository,
+  private val planRepository: PlanRepository,
   private val versionService: VersionService,
   private val planVersionRepository: PlanVersionRepository,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
@@ -19,6 +19,8 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.getPlanByUuid
+import uk.gov.justice.digital.hmpps.sentenceplan.exceptions.NotFoundException
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
@@ -39,8 +41,8 @@ class GoalService(
     val planVersionEntity: PlanVersionEntity
 
     try {
-      planVersionEntity = planRepository.findByUuid(planUuid).currentVersion!!
-    } catch (e: EmptyResultDataAccessException) {
+      planVersionEntity = planRepository.getPlanByUuid(planUuid).currentVersion!!
+    } catch (e: NotFoundException) {
       throw Exception("A Plan with this UUID was not found: $planUuid")
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
@@ -14,12 +14,11 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalNoteEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalNoteType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalStatus
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntityRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepRepository
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.getPlanByUuid
 import uk.gov.justice.digital.hmpps.sentenceplan.exceptions.NotFoundException
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -30,7 +29,7 @@ class GoalService(
   private val goalRepository: GoalRepository,
   private val areaOfNeedRepository: AreaOfNeedRepository,
   private val stepRepository: StepRepository,
-  private val planRepository: PlanRepository,
+  private val planRepository: PlanEntityRepository,
   private val versionService: VersionService,
   private val planVersionRepository: PlanVersionRepository,
 ) {
@@ -41,7 +40,7 @@ class GoalService(
     val planVersionEntity: PlanVersionEntity
 
     try {
-      planVersionEntity = planRepository.getPlanByUuid(planUuid).currentVersion!!
+      planVersionEntity = planRepository.getByUuid(planUuid).currentVersion!!
     } catch (e: NotFoundException) {
       throw Exception("A Plan with this UUID was not found: $planUuid")
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanAgreementNoteEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanAgreementNoteRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanAgreementStatus
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntityRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
@@ -27,7 +27,7 @@ import java.util.UUID
 
 @Service
 class PlanService(
-  private val planRepository: PlanEntityRepository,
+  private val planRepository: PlanRepository,
   private val planVersionRepository: PlanVersionRepository,
   private val planAgreementNoteRepository: PlanAgreementNoteRepository,
   private val versionService: VersionService,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
@@ -16,12 +16,14 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.getPlanByUuid
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.getVersionByUuidAndVersion
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.CounterSignPlanRequest
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.CountersignType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.SignRequest
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.SignType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.response.SoftDeletePlanVersionsResponse
 import uk.gov.justice.digital.hmpps.sentenceplan.exceptions.ConflictException
+import uk.gov.justice.digital.hmpps.sentenceplan.exceptions.NotFoundException
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -38,7 +40,11 @@ class PlanService(
     return planEntity.currentVersion!!
   }
 
-  fun getPlanVersionByPlanUuidAndPlanVersion(planUuid: UUID, planVersion: Int): PlanVersionEntity = planVersionRepository.getVersionByUuidAndVersion(planUuid, planVersion)
+  fun getPlanVersionByPlanUuidAndPlanVersion(planUuid: UUID, planVersion: Int): PlanVersionEntity = try {
+    planVersionRepository.getVersionByUuidAndVersion(planUuid, planVersion)
+  } catch (e: EmptyResultDataAccessException) {
+    throw NotFoundException("Could not find a plan with ID: $planUuid and version number: $planVersion")
+  }
 
   fun rollbackVersion(planUuid: UUID, versionNumber: Int): PlanVersionEntity {
     val version = planVersionRepository.getVersionByUuidAndVersion(planUuid, versionNumber)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
@@ -16,7 +16,6 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.getPlanByUuid
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.getVersionByUuidAndVersion
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.CounterSignPlanRequest
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.CountersignType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.SignRequest

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.sentenceplan.services
 
 import jakarta.validation.ValidationException
+import org.springframework.dao.EmptyResultDataAccessException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.sentenceplan.data.Agreement
@@ -21,6 +22,7 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.SignRequest
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.SignType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.response.SoftDeletePlanVersionsResponse
 import uk.gov.justice.digital.hmpps.sentenceplan.exceptions.ConflictException
+import uk.gov.justice.digital.hmpps.sentenceplan.exceptions.NotFoundException
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -254,5 +256,11 @@ class PlanService(
   }
 
   @Transactional
-  fun getPlanAndGoalNotes(planUuid: UUID): List<Note> = planRepository.getPlanAndGoalNotes(planUuid)
+  fun getPlanAndGoalNotes(planUuid: UUID): List<Note> {
+    try {
+      return planRepository.getPlanAndGoalNotes(planUuid)
+    } catch (e: EmptyResultDataAccessException) {
+      throw NotFoundException("Plan not found for id $planUuid")
+    }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
@@ -16,7 +16,6 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.getPlanByUuid
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.getVersionByUuidAndVersion
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.CounterSignPlanRequest
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.CountersignType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.SignRequest
@@ -172,7 +171,7 @@ class PlanService(
 
     versionService.alwaysCreateNewPlanVersion(planVersion)
 
-    val signedPlan = planVersionRepository.findByPlanUuidAndVersionNumber(planUuid, planVersion.version)
+    val signedPlan = planVersionRepository.getVersionByUuidAndVersion(planUuid, planVersion.version)
 
     when (signRequest.signType) {
       SignType.SELF -> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
@@ -35,15 +35,15 @@ class PlanService(
 ) {
 
   fun getPlanVersionByPlanUuid(planUuid: UUID): PlanVersionEntity {
-    val planEntity = planRepository.findByUuid(planUuid)
-    return planEntity.currentVersion!!
+    try {
+      val planEntity = planRepository.findByUuid(planUuid)
+      return planEntity.currentVersion!!
+    } catch (e: EmptyResultDataAccessException) {
+      throw NotFoundException("Could not find a plan with ID: $planUuid")
+    }
   }
 
-  fun getPlanVersionByPlanUuidAndPlanVersion(planUuid: UUID, planVersion: Int): PlanVersionEntity = try {
-    planVersionRepository.getVersionByUuidAndVersion(planUuid, planVersion)
-  } catch (e: EmptyResultDataAccessException) {
-    throw NotFoundException("Could not find a plan with ID: $planUuid and version number: $planVersion")
-  }
+  fun getPlanVersionByPlanUuidAndPlanVersion(planUuid: UUID, planVersion: Int): PlanVersionEntity = planVersionRepository.getVersionByUuidAndVersion(planUuid, planVersion)
 
   fun rollbackVersion(planUuid: UUID, versionNumber: Int): PlanVersionEntity {
     val version = planVersionRepository.getVersionByUuidAndVersion(planUuid, versionNumber)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionService.kt
@@ -10,7 +10,6 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.AreaOfNeedEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.getNextPlanVersion
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 import java.util.UUID

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionService.kt
@@ -78,7 +78,7 @@ class VersionService(
     entityManager.detach(newPlanVersionEntity)
 
     val currentPlanVersion = planVersionRepository.findByUuid(planVersionUuid)
-    currentPlanVersion.version = planVersionRepository.getNextPlanVersion(currentPlanVersion.planId)
+    currentPlanVersion.version = planVersionRepository.findNextPlanVersion(currentPlanVersion.planId)
     val updatedCurrentVersion = planVersionRepository.save(currentPlanVersion)
 
     entityManager.flush()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/CoordinatorControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/CoordinatorControllerTest.kt
@@ -24,7 +24,6 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.getPlanByUuid
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.getVersionByUuidAndVersion
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.ClonePlanVersionRequest
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.CounterSignPlanRequest
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.CountersignType
@@ -522,7 +521,7 @@ class CoordinatorControllerTest : IntegrationTestBase() {
         .expectBody<ErrorResponse>()
         .returnResult().responseBody
 
-      assertThat(response.userMessage).isEqualTo("Validation failure: The specified range contains version(s) (3, 4) that do not exist or have already had soft_deleted set to true")
+      assertThat(response?.userMessage).isEqualTo("Validation failure: The specified range contains version(s) (3, 4) that do not exist or have already had soft_deleted set to true")
     }
 
     @Test
@@ -637,7 +636,7 @@ class CoordinatorControllerTest : IntegrationTestBase() {
         .expectBody<ErrorResponse>()
         .returnResult().responseBody
 
-      assertThat(response.userMessage).isEqualTo("Validation failure: The specified range contains version(s) (5) that do not exist or have already had soft_deleted set to false")
+      assertThat(response?.userMessage).isEqualTo("Validation failure: The specified range contains version(s) (5) that do not exist or have already had soft_deleted set to false")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/CoordinatorControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/CoordinatorControllerTest.kt
@@ -672,7 +672,7 @@ class CoordinatorControllerTest : IntegrationTestBase() {
     @Sql(scripts = ["/db/test/plan_cleanup.sql"], executionPhase = AFTER_TEST_METHOD)
     @Test
     fun `should clone the latest version into a new version`() {
-      val beforePlan = planRepository.findPlanByUuid(planUuid)
+      val beforePlan = planRepository.getPlanByUuid(planUuid)
       assertThat(beforePlan?.currentVersion?.version).isEqualTo(0L)
 
       val clonePlanVersionRequest = ClonePlanVersionRequest(
@@ -690,7 +690,7 @@ class CoordinatorControllerTest : IntegrationTestBase() {
         .expectBody<PlanVersionResponse>()
         .returnResult().responseBody
 
-      val afterPlan = planRepository.findPlanByUuid(planUuid)
+      val afterPlan = planRepository.getPlanByUuid(planUuid)
       assertThat(afterPlan?.currentVersion?.version).isEqualTo(1L)
       assertThat(afterPlan?.currentVersion?.planType).isEqualTo(PlanType.OTHER)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/CoordinatorControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/CoordinatorControllerTest.kt
@@ -75,11 +75,11 @@ class CoordinatorControllerTest : IntegrationTestBase() {
       assertThat(responseBody?.planVersion).isEqualTo(0L)
       assertThat(responseBody?.planId).isNotNull
 
-      planRepository.findPlanByUuid(responseBody.planId).let {
-        assertThat(it?.currentVersion?.version).isEqualTo(0)
-        assertThat(it?.currentVersion?.planType).isEqualTo(planType)
-        assertThat(it?.lastUpdatedBy?.username).isEqualTo(userDetails.name)
-        assertThat(it?.createdBy?.username).isEqualTo(userDetails.name)
+      planRepository.getByUuid(responseBody!!.planId).let {
+        assertThat(it.currentVersion?.version).isEqualTo(0)
+        assertThat(it.currentVersion?.planType).isEqualTo(planType)
+        assertThat(it.lastUpdatedBy?.username).isEqualTo(userDetails.name)
+        assertThat(it.createdBy?.username).isEqualTo(userDetails.name)
       }
     }
   }
@@ -672,7 +672,7 @@ class CoordinatorControllerTest : IntegrationTestBase() {
     @Test
     fun `should clone the latest version into a new version`() {
       val beforePlan = planRepository.getByUuid(planUuid)
-      assertThat(beforePlan?.currentVersion?.version).isEqualTo(0L)
+      assertThat(beforePlan.currentVersion?.version).isEqualTo(0L)
 
       val clonePlanVersionRequest = ClonePlanVersionRequest(
         planType = PlanType.OTHER,
@@ -690,8 +690,8 @@ class CoordinatorControllerTest : IntegrationTestBase() {
         .returnResult().responseBody
 
       val afterPlan = planRepository.getByUuid(planUuid)
-      assertThat(afterPlan?.currentVersion?.version).isEqualTo(1L)
-      assertThat(afterPlan?.currentVersion?.planType).isEqualTo(PlanType.OTHER)
+      assertThat(afterPlan.currentVersion?.version).isEqualTo(1L)
+      assertThat(afterPlan.currentVersion?.planType).isEqualTo(PlanType.OTHER)
 
       assertThat(response?.planVersion).isEqualTo(1L)
       assertThat(response?.planId).isEqualTo(planUuid)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/CoordinatorControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/CoordinatorControllerTest.kt
@@ -266,7 +266,7 @@ class CoordinatorControllerTest : IntegrationTestBase() {
           assertThat(responseBody?.planVersion).isEqualTo(beforeVersion.toLong())
         }
 
-      val afterStatus = planVersionRepository.findByPlanUuidAndVersionNumber(planUuid, beforeVersion).status
+      val afterStatus = planVersionRepository.getVersionByUuidAndVersion(planUuid, beforeVersion).status
       val newPlanVersion = planRepository.getPlanByUuid(planUuid).currentVersion
 
       assertThat(afterStatus).isNotEqualTo(beforeVersionStatus)
@@ -328,7 +328,7 @@ class CoordinatorControllerTest : IntegrationTestBase() {
           assertThat(responseBody?.planVersion).isEqualTo(beforeVersion.toLong())
         }
 
-      val afterStatus = planVersionRepository.findByPlanUuidAndVersionNumber(planUuid, beforeVersion).status
+      val afterStatus = planVersionRepository.getVersionByUuidAndVersion(planUuid, beforeVersion).status
 
       assertThat(afterStatus).isNotEqualTo(beforeVersionStatus)
       assertThat(afterStatus).isEqualTo(CountersigningStatus.ROLLED_BACK)
@@ -391,7 +391,7 @@ class CoordinatorControllerTest : IntegrationTestBase() {
           assertThat(responseBody?.planVersion).isEqualTo(beforeVersion.toLong())
         }
 
-      val afterStatus = planVersionRepository.findByPlanUuidAndVersionNumber(planUuid, beforeVersion).status
+      val afterStatus = planVersionRepository.getVersionByUuidAndVersion(planUuid, beforeVersion).status
 
       assertThat(afterStatus).isNotEqualTo(beforeVersionStatus)
       assertThat(afterStatus).isEqualTo(CountersigningStatus.AWAITING_DOUBLE_COUNTERSIGN)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/CoordinatorControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/CoordinatorControllerTest.kt
@@ -20,7 +20,7 @@ import uk.gov.justice.digital.hmpps.sentenceplan.data.CreatePlanRequest
 import uk.gov.justice.digital.hmpps.sentenceplan.data.LockPlanRequest
 import uk.gov.justice.digital.hmpps.sentenceplan.data.UserDetails
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.CountersigningStatus
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntityRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.ClonePlanVersionRequest
@@ -45,7 +45,7 @@ class CoordinatorControllerTest : IntegrationTestBase() {
   val userDetails = UserDetails("1", "Tom C")
 
   @Autowired
-  lateinit var planRepository: PlanEntityRepository
+  lateinit var planRepository: PlanRepository
 
   @Autowired
   lateinit var planVersionRepository: PlanVersionRepository

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
@@ -242,14 +242,14 @@ class GoalControllerTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `create goal steps should throw a DataIntegrityViolationException if the Goal GUID doesn't exist`() {
+    fun `create goal steps should throw a 404 if the Goal GUID doesn't exist`() {
       val randomUuid = UUID.randomUUID()
       webTestClient.post().uri("/goals/$randomUuid/steps")
         .header("Content-Type", "application/json")
         .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_SENTENCE_PLAN_READ", "ROLE_SENTENCE_PLAN_WRITE")))
         .bodyValue(stepList)
         .exchange()
-        .expectStatus().is5xxServerError
+        .expectStatus().isNotFound
         .expectBody<ErrorResponse>()
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/PlanControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/PlanControllerTest.kt
@@ -131,7 +131,7 @@ class PlanControllerTest : IntegrationTestBase() {
         .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_SENTENCE_PLAN_READ", "ROLE_SENTENCE_PLAN_WRITE")))
         .bodyValue(goalRequestBodyBadAreaOfNeed)
         .exchange()
-        .expectStatus().is5xxServerError
+        .expectStatus().isNotFound
         .expectBody<ErrorResponse>()
     }
 
@@ -147,11 +147,11 @@ class PlanControllerTest : IntegrationTestBase() {
         .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_SENTENCE_PLAN_READ", "ROLE_SENTENCE_PLAN_WRITE")))
         .bodyValue(goalRequestBodyBadAreaOfNeed)
         .exchange()
-        .expectStatus().is5xxServerError
+        .expectStatus().isNotFound
         .expectBody<ErrorResponse>()
         .returnResult().responseBody
 
-      assertThat(errorResponse?.developerMessage).startsWith("A Plan with this UUID was not found:")
+      assertThat(errorResponse?.developerMessage).startsWith("Plan not found for id")
     }
 
     @Test
@@ -247,13 +247,13 @@ class PlanControllerTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `should return server error when creating goal with invalid Plan UUID`() {
+    fun `should return 404 error when creating goal with invalid Plan UUID`() {
       val randomPlanUuid = UUID.randomUUID()
       webTestClient.post().uri("/plans/$randomPlanUuid/goals").header("Content-Type", "application/json")
         .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_SENTENCE_PLAN_READ", "ROLE_SENTENCE_PLAN_WRITE")))
         .bodyValue(goalRequestBody)
         .exchange()
-        .expectStatus().is5xxServerError
+        .expectStatus().isNotFound
         .expectBody<ErrorResponse>()
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanProgressNotesReposit
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepStatus
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.getVersionByUuidAndVersion
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.SignRequest
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.SignType
 import uk.gov.justice.digital.hmpps.sentenceplan.services.GoalService

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
@@ -19,8 +19,8 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.CountersigningStatus
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalStatus
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanAgreementStatus
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntityRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanProgressNotesRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepStatus
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.SignRequest
@@ -42,7 +42,7 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
   lateinit var versionService: VersionService
 
   @Autowired
-  lateinit var planRepository: PlanEntityRepository
+  lateinit var planRepository: PlanRepository
 
   @Autowired
   lateinit var planVersionRepository: PlanVersionRepository

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
@@ -19,8 +19,8 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.CountersigningStatus
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalStatus
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanAgreementStatus
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntityRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanProgressNotesRepository
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepStatus
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.SignRequest
@@ -42,7 +42,7 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
   lateinit var versionService: VersionService
 
   @Autowired
-  lateinit var planRepository: PlanRepository
+  lateinit var planRepository: PlanEntityRepository
 
   @Autowired
   lateinit var planVersionRepository: PlanVersionRepository
@@ -96,7 +96,7 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
     assertThat(planVersionRepository.findAll().size).isEqualTo(2)
 
     // check that when fetched the plan references the version with ID 1
-    val planEntity = planRepository.findByUuid(testPlanUuid)
+    val planEntity = planRepository.getByUuid(testPlanUuid)
     assertThat(planEntity.currentVersion!!.version).isEqualTo(1)
 
     // check that the UUID of version 0 is now different to the original UUID

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
@@ -23,7 +23,6 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanProgressNotesReposit
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepStatus
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.getVersionByUuidAndVersion
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.SignRequest
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.SignType
 import uk.gov.justice.digital.hmpps.sentenceplan.services.GoalService

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/VersionServiceIntegrationTest.kt
@@ -100,7 +100,7 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
     assertThat(planEntity.currentVersion!!.version).isEqualTo(1)
 
     // check that the UUID of version 0 is now different to the original UUID
-    val planVersionZero = planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 0)
+    val planVersionZero = planVersionRepository.getVersionByUuidAndVersion(testPlanUuid, 0)
     assertThat(planVersionZero.uuid).isNotEqualTo(testPlanVersionUuid)
 
     // check that both versions reference the same plan
@@ -153,8 +153,8 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
 
     assertThat(planVersionRepository.findAll().size).isEqualTo(2)
 
-    assertThat(planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 0).goals.size).isEqualTo(0)
-    assertThat(planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 1).goals.size).isEqualTo(1)
+    assertThat(planVersionRepository.getVersionByUuidAndVersion(testPlanUuid, 0).goals.size).isEqualTo(0)
+    assertThat(planVersionRepository.getVersionByUuidAndVersion(testPlanUuid, 1).goals.size).isEqualTo(1)
 
     assertThat(planVersionRepository.findByUuid(testPlanVersionUuid).goals.size).isEqualTo(1)
   }
@@ -179,14 +179,14 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
     // we should now have two versions, original and once made when adding steps
     assertThat(planVersionRepository.findAll().size).isEqualTo(2)
 
-    assertThat(planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 0).goals.size).isEqualTo(2)
-    assertThat(planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 1).goals.size).isEqualTo(2)
+    assertThat(planVersionRepository.getVersionByUuidAndVersion(testPlanUuid, 0).goals.size).isEqualTo(2)
+    assertThat(planVersionRepository.getVersionByUuidAndVersion(testPlanUuid, 1).goals.size).isEqualTo(2)
 
-    val planVersionZero = planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 0)
+    val planVersionZero = planVersionRepository.getVersionByUuidAndVersion(testPlanUuid, 0)
     val wholePlanVersionZero = planVersionRepository.getWholePlanVersionByUuid(planVersionZero.uuid)
     assertThat(wholePlanVersionZero.goals.first().steps.size).isEqualTo(0)
 
-    val planVersionOne = planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 1)
+    val planVersionOne = planVersionRepository.getVersionByUuidAndVersion(testPlanUuid, 1)
     val wholePlanVersionOne = planVersionRepository.getWholePlanVersionByUuid(planVersionOne.uuid)
     assertThat(wholePlanVersionOne.goals.first().steps.size).isEqualTo(1)
   }
@@ -207,14 +207,14 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
     // we should now have two planversions, original and once made when adding the new step
     assertThat(planVersionRepository.findAll().size).isEqualTo(2)
 
-    assertThat(planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 0).goals.size).isEqualTo(2)
-    assertThat(planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 1).goals.size).isEqualTo(2)
+    assertThat(planVersionRepository.getVersionByUuidAndVersion(testPlanUuid, 0).goals.size).isEqualTo(2)
+    assertThat(planVersionRepository.getVersionByUuidAndVersion(testPlanUuid, 1).goals.size).isEqualTo(2)
 
-    val planVersionZero = planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 0)
+    val planVersionZero = planVersionRepository.getVersionByUuidAndVersion(testPlanUuid, 0)
     val wholePlanVersionZero = planVersionRepository.getWholePlanVersionByUuid(planVersionZero.uuid)
     assertThat(wholePlanVersionZero.goals.first().steps.size).isEqualTo(1)
 
-    val planVersionOne = planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 1)
+    val planVersionOne = planVersionRepository.getVersionByUuidAndVersion(testPlanUuid, 1)
     val wholePlanVersionOne = planVersionRepository.getWholePlanVersionByUuid(planVersionOne.uuid)
     assertThat(wholePlanVersionOne.goals.first().steps.size).isEqualTo(2)
   }
@@ -240,8 +240,8 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
     // we should now have two PlanVersions, original and once made when agreeing the Plan
     assertThat(planVersionRepository.findAll().size).isEqualTo(2)
 
-    val planVersionZero = planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 0)
-    val planVersionOne = planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 1)
+    val planVersionZero = planVersionRepository.getVersionByUuidAndVersion(testPlanUuid, 0)
+    val planVersionOne = planVersionRepository.getVersionByUuidAndVersion(testPlanUuid, 1)
 
     assertThat(planVersionZero.agreementNote).isNull()
     assertThat(planVersionOne.agreementNote).isNotNull
@@ -269,8 +269,8 @@ class VersionServiceIntegrationTest : IntegrationTestBase() {
     // we should now have two plan versions, original and one made before signing the Plan
     assertThat(planVersionRepository.findAll().size).isEqualTo(2)
 
-    val planVersionZero = planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 0)
-    val planVersionOne = planVersionRepository.findByPlanUuidAndVersionNumber(testPlanUuid, 1)
+    val planVersionZero = planVersionRepository.getVersionByUuidAndVersion(testPlanUuid, 0)
+    val planVersionOne = planVersionRepository.getVersionByUuidAndVersion(testPlanUuid, 1)
 
     assertThat(planVersionZero.status).isEqualTo(CountersigningStatus.SELF_SIGNED)
     assertThat(planVersionOne.status).isEqualTo(CountersigningStatus.UNSIGNED)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
@@ -23,7 +23,7 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalNoteType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalStatus
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntityRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
@@ -38,7 +38,7 @@ import java.util.UUID
 class GoalServiceTest {
   private val goalRepository: GoalRepository = mockk()
   private val areaOfNeedRepository: AreaOfNeedRepository = mockk()
-  private val planRepository: PlanRepository = mockk()
+  private val planRepository: PlanEntityRepository = mockk()
   private val planVersionRepository: PlanVersionRepository = mockk()
   private val stepRepository: StepRepository = mockk()
   private val versionService: VersionService = mockk()
@@ -125,7 +125,7 @@ class GoalServiceTest {
 
     @Test
     fun `create new goal with random Plan UUID should throw Exception`() {
-      every { planRepository.findByUuid(any()) } throws EmptyResultDataAccessException(1)
+      every { planRepository.getByUuid(any()) } throws EmptyResultDataAccessException(1)
 
       val exception = assertThrows<Exception> {
         goalService.createNewGoal(UUID.randomUUID(), goal)
@@ -136,7 +136,7 @@ class GoalServiceTest {
 
     @Test
     fun `create new goal with Area Of Need that doesn't exist should throw Exception`() {
-      every { planRepository.findByUuid(any()) } returns planEntity
+      every { planRepository.getByUuid(any()) } returns planEntity
       every { areaOfNeedRepository.findByNameIgnoreCase(any()) } throws EmptyResultDataAccessException(1)
       every { versionService.conditionallyCreateNewPlanVersion(any()) } returns newPlanVersionEntity
 
@@ -156,7 +156,7 @@ class GoalServiceTest {
 
     @Test
     fun `create new goal with Related Areas Of Need that don't exist should throw Exception`() {
-      every { planRepository.findByUuid(any()) } returns planEntity
+      every { planRepository.getByUuid(any()) } returns planEntity
       every { areaOfNeedRepository.findByNameIgnoreCase(any()) } returns areaOfNeedEntity
       every { areaOfNeedRepository.findAllByNames(any()) } returns null
       every { versionService.conditionallyCreateNewPlanVersion(any()) } returns newPlanVersionEntity
@@ -177,7 +177,7 @@ class GoalServiceTest {
 
     @Test
     fun `create new goal with no Related Areas of Need should call save`() {
-      every { planRepository.findByUuid(any()) } returns planEntity
+      every { planRepository.getByUuid(any()) } returns planEntity
       every { areaOfNeedRepository.findByNameIgnoreCase(any()) } returns areaOfNeedEntity
       every { areaOfNeedRepository.findAllByNames(any()) } returns null
       every { versionService.conditionallyCreateNewPlanVersion(any()) } returns newPlanVersionEntity
@@ -193,7 +193,7 @@ class GoalServiceTest {
 
     @Test
     fun `creating two goals should set incrementing goal order values`() {
-      every { planRepository.findByUuid(any()) } returns planEntity
+      every { planRepository.getByUuid(any()) } returns planEntity
       every { areaOfNeedRepository.findByNameIgnoreCase(any()) } returns areaOfNeedEntity
       every { areaOfNeedRepository.findAllByNames(any()) } returns null
       every { versionService.conditionallyCreateNewPlanVersion(any()) } returns newPlanVersionEntity

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
@@ -446,7 +446,7 @@ class GoalServiceTest {
       assertThat(savedGoal.notes.first().type).isEqualTo(GoalNoteType.READDED)
       assertThat(savedGoal.relatedAreasOfNeed?.size).isEqualTo(1)
       assertThat(savedGoal.status).isEqualTo(GoalStatus.ACTIVE)
-      assertThat(savedGoal.targetDate).isEqualTo(LocalDate.parse(goalUpdate.targetDate))
+      assertThat(savedGoal.targetDate).isEqualTo(LocalDate.parse(goalUpdate.targetDate!!))
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
@@ -23,7 +23,7 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalNoteType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalStatus
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntityRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
@@ -39,7 +39,7 @@ import java.util.UUID
 class GoalServiceTest {
   private val goalRepository: GoalRepository = mockk()
   private val areaOfNeedRepository: AreaOfNeedRepository = mockk()
-  private val planRepository: PlanEntityRepository = mockk()
+  private val planRepository: PlanRepository = mockk()
   private val planVersionRepository: PlanVersionRepository = mockk()
   private val stepRepository: StepRepository = mockk()
   private val versionService: VersionService = mockk()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalServiceTest.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepStatus
+import uk.gov.justice.digital.hmpps.sentenceplan.exceptions.NotFoundException
 import java.time.LocalDate
 import java.util.UUID
 
@@ -125,13 +126,13 @@ class GoalServiceTest {
 
     @Test
     fun `create new goal with random Plan UUID should throw Exception`() {
-      every { planRepository.getByUuid(any()) } throws EmptyResultDataAccessException(1)
+      every { planRepository.getByUuid(any()) } throws NotFoundException("Plan not found for id")
 
-      val exception = assertThrows<Exception> {
+      val exception = assertThrows<NotFoundException> {
         goalService.createNewGoal(UUID.randomUUID(), goal)
       }
 
-      assertThat(exception.message).startsWith("A Plan with this UUID was not found:")
+      assertThat(exception.message).startsWith("Plan not found for id")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
@@ -28,7 +28,6 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.getVersionByUuidAndVersion
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.CounterSignPlanRequest
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.CountersignType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.SignRequest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.sentenceplan.services
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import jakarta.persistence.EntityManager
 import jakarta.validation.ValidationException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -18,15 +17,12 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.kotlin.any
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
 import uk.gov.justice.digital.hmpps.sentenceplan.data.Agreement
 import uk.gov.justice.digital.hmpps.sentenceplan.data.UserDetails
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.CountersigningStatus
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanAgreementNoteRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanAgreementStatus
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntityExceptionHandlingRepositoryImpl
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntityRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
@@ -481,14 +477,4 @@ class PlanServiceTest {
       assertThat(result.planType).isEqualTo(PlanType.OTHER)
     }
   }
-}
-
-@Configuration
-class TestConfig {
-
-  @Bean
-  fun entityManager(): EntityManager = mockk()
-
-  @Bean
-  fun planEntityExceptionHandlingRepositoryImpl(entityManager: EntityManager): PlanEntityExceptionHandlingRepositoryImpl = PlanEntityExceptionHandlingRepositoryImpl(entityManager)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
@@ -28,7 +28,6 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.getVersionByUuidAndVersion
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.CounterSignPlanRequest
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.CountersignType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.SignRequest
@@ -56,7 +55,10 @@ class PlanServiceTest {
     planVersionEntity = PlanVersionEntity(id = 0, plan = planEntity, planId = 0L, version = 0)
     newPlanVersionEntity = PlanVersionEntity(id = 1, plan = planEntity, planId = 0L, version = 1)
     agreedNewPlanVersionEntity = PlanVersionEntity(
-      id = 1, plan = planEntity, planId = 0L, version = 1,
+      id = 1,
+      plan = planEntity,
+      planId = 0L,
+      version = 1,
       agreementStatus = PlanAgreementStatus.AGREED,
     )
     planEntity.currentVersion = planVersionEntity
@@ -168,7 +170,7 @@ class PlanServiceTest {
     fun `should mark plan as self-signed`() {
       every { planRepository.findByUuid(any()) } returns planEntity.apply { currentVersion?.agreementStatus = PlanAgreementStatus.AGREED }
       every { planVersionRepository.save(any()) } returnsArgument 0
-      every { planVersionRepository.findByPlanUuidAndVersionNumber(any(), any()) } returns newPlanVersionEntity
+      every { planVersionRepository.getVersionByUuidAndVersion(any(), any()) } returns newPlanVersionEntity
       every { versionService.alwaysCreateNewPlanVersion(any()) } returns newPlanVersionEntity
 
       val signRequest = SignRequest(
@@ -185,7 +187,7 @@ class PlanServiceTest {
     fun `should mark plan as awaiting-countersign`() {
       every { planRepository.findByUuid(any()) } returns planEntity.apply { currentVersion?.agreementStatus = PlanAgreementStatus.AGREED }
       every { planVersionRepository.save(any()) } returnsArgument 0
-      every { planVersionRepository.findByPlanUuidAndVersionNumber(any(), any()) } returns newPlanVersionEntity
+      every { planVersionRepository.getVersionByUuidAndVersion(any(), any()) } returns newPlanVersionEntity
       every { versionService.conditionallyCreateNewPlanVersion(any()) } returns newPlanVersionEntity
 
       val signRequest = SignRequest(
@@ -444,7 +446,9 @@ class PlanServiceTest {
       val planUUID = planEntity.uuid
       val updatedPlanEntity = planEntity.apply {
         currentVersion = PlanVersionEntity(
-          id = 1, plan = planEntity, planId = 0L,
+          id = 1,
+          plan = planEntity,
+          planId = 0L,
           version = planEntity.currentVersion!!.version.inc(),
         )
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
@@ -28,11 +28,13 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.getVersionByUuidAndVersion
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.CounterSignPlanRequest
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.CountersignType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.SignRequest
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.request.SignType
 import uk.gov.justice.digital.hmpps.sentenceplan.exceptions.ConflictException
+import uk.gov.justice.digital.hmpps.sentenceplan.exceptions.NotFoundException
 import java.util.UUID
 import java.util.stream.Stream
 
@@ -88,6 +90,37 @@ class PlanServiceTest {
       }
 
       assertEquals("Incorrect result size: expected 1, actual 0", exception.message)
+    }
+  }
+
+  @Nested
+  @DisplayName("getPlanVersionByPlanUuidAndPlanVersion")
+  inner class GetPlanVersionByPlanUuidAndPlanVersion {
+
+    @Test
+    fun `should return plan version when plan exists with given UUID and version`() {
+      val planUuid = UUID.randomUUID()
+      val planVersion = 1
+
+      every { planVersionRepository.getVersionByUuidAndVersion(planUuid, planVersion) } returns planVersionEntity
+
+      val result = planService.getPlanVersionByPlanUuidAndPlanVersion(planUuid, planVersion)
+
+      assertEquals(planVersionEntity, result)
+    }
+
+    @Test
+    fun `should throw NotFoundException when no plan exists with given UUID and version`() {
+      val planUuid = UUID.randomUUID()
+      val planVersion = 1
+
+      every { planVersionRepository.getVersionByUuidAndVersion(planUuid, planVersion) } throws EmptyResultDataAccessException(1)
+
+      val exception = assertThrows(NotFoundException::class.java) {
+        planService.getPlanVersionByPlanUuidAndPlanVersion(planUuid, planVersion)
+      }
+
+      assertEquals("Could not find a plan with ID: $planUuid and version number: $planVersion", exception.message)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
@@ -91,7 +91,7 @@ class PlanServiceTest {
         planService.getPlanVersionByPlanUuid(planUuid)
       }
 
-      assertEquals("Could not find a plan with ID: $planUuid", exception.message)
+      assertEquals("Plan not found for id $planUuid", exception.message)
     }
   }
 
@@ -171,11 +171,11 @@ class PlanServiceTest {
     fun `should throw exception when plan not found`() {
       every { planRepository.findByUuid(any()) } throws EmptyResultDataAccessException(1)
 
-      val exception = assertThrows(EmptyResultDataAccessException::class.java) {
+      val exception = assertThrows(NotFoundException::class.java) {
         planService.agreeLatestPlanVersion(UUID.fromString("1c93ebe7-1d8d-4fcc-aef2-f97c4c983a6b"), agreement)
       }
 
-      assertEquals("Plan was not found with UUID: 1c93ebe7-1d8d-4fcc-aef2-f97c4c983a6b", exception.message)
+      assertEquals("Plan not found for id 1c93ebe7-1d8d-4fcc-aef2-f97c4c983a6b", exception.message)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt
@@ -23,7 +23,7 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.CountersigningStatus
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanAgreementNoteRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanAgreementStatus
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
-import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntityRepository
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanRepository
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanType
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionRepository
@@ -39,7 +39,7 @@ import java.util.stream.Stream
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PlanServiceTest {
 
-  private val planRepository: PlanEntityRepository = mockk()
+  private val planRepository: PlanRepository = mockk()
   private val planVersionRepository: PlanVersionRepository = mockk(relaxed = true)
   private val planAgreementNoteRepository: PlanAgreementNoteRepository = mockk()
   private val versionService: VersionService = mockk<VersionService>(relaxed = true)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/VersionServiceTest.kt
@@ -34,7 +34,7 @@ class VersionServiceTest {
     every { planVersionRepository.getWholePlanVersionByUuid(any()) } returns planVersionEntity
     every { planVersionRepository.findByUuid(any()) } returns planVersionEntity
     every { planVersionRepository.save(any()) } returns newPlanVersionEntity
-    every { planVersionRepository.findLatestPlanVersion(any()) } returns newPlanVersionEntity.version.inc()
+    every { planVersionRepository.findNextPlanVersion(any()) } returns newPlanVersionEntity.version.inc()
 
     versionService.entityManager = mockk<EntityManager>(relaxed = true)
   }


### PR DESCRIPTION
This PR does three related things:

1. It pushes the handling of JPA exceptions out of the Controller layer in favour of the Service and Respository layers.
2. It removes the throwing of raw `Exception`s in favour of specific exception types.
3. It creates two new Repository classes in order to centralise exception handling for queries that are frequently used across the codebase and where that exception handling was duplicated in many places.

The first two changes are straightforward - you should be able to review the modified Controllers and check that they no longer catch JPA exceptions (e.g. `EmptyResultDataAccessException`), and examine `GoalService` to see the removal of `throw Exception`.

The third change is a bit more complicated. Two new files have been added:

1. src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/repository/PlanEntityExceptionHandlingRepository.kt
2. src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/repository/PlanVersionExceptionHandlingRepositoryImpl.kt

These two repository classes are extended by the main PlanRepository and PlanVersionRepository respectively and deal with exceptions directly so that they are no longer either propagated to the Controller or handled by duplicated try..catch statements.

Because these are mostly changes to the internal organisation of the code there is only one new test (in `src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanServiceTest.kt`), the rest have been updated to use the new functional calls and exception types.