### PR TITLE
SP2-1535 Adds new controller endpoints which wrap around updateGoalStatus

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/GoalController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/GoalController.kt
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.resource.NoResourceFoundException
 import uk.gov.justice.digital.hmpps.sentenceplan.data.Goal
 import uk.gov.justice.digital.hmpps.sentenceplan.data.GoalOrder
-import uk.gov.justice.digital.hmpps.sentenceplan.data.ReAddGoal
 import uk.gov.justice.digital.hmpps.sentenceplan.data.Step
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalStatus
@@ -62,9 +61,9 @@ class GoalController(private val service: GoalService) {
   @ResponseStatus(HttpStatus.OK)
   fun achieveGoal(
     @PathVariable goalUuid: UUID,
-    @RequestBody note: String,
+    @RequestBody achieveGoal: Goal,
   ): GoalEntity {
-    val goal = Goal(status = GoalStatus.ACHIEVED, note = note)
+    val goal = Goal(status = GoalStatus.ACHIEVED, note = achieveGoal.note)
     return service.updateGoalStatus(goalUuid, goal)
   }
 
@@ -73,9 +72,9 @@ class GoalController(private val service: GoalService) {
   @ResponseStatus(HttpStatus.OK)
   fun removeGoal(
     @PathVariable goalUuid: UUID,
-    @RequestBody note: String,
+    @RequestBody removeGoal: Goal,
   ): GoalEntity {
-    val goal = Goal(status = GoalStatus.REMOVED, note = note)
+    val goal = Goal(status = GoalStatus.REMOVED, note = removeGoal.note)
     return service.updateGoalStatus(goalUuid, goal)
   }
 
@@ -84,18 +83,10 @@ class GoalController(private val service: GoalService) {
   @ResponseStatus(HttpStatus.OK)
   fun reAddGoal(
     @PathVariable goalUuid: UUID,
-    @RequestBody reAddGoal: ReAddGoal,
+    @RequestBody reAddGoal: Goal,
   ): GoalEntity {
-    var goalStatus = GoalStatus.FUTURE
-    if (!reAddGoal.targetDate.isNullOrEmpty()) {
-      goalStatus = GoalStatus.ACTIVE
-    }
-    val goal = Goal(
-      note = reAddGoal.note,
-      targetDate = reAddGoal.targetDate,
-      status = goalStatus,
-    )
-    return service.updateGoalStatus(goalUuid, goal)
+    reAddGoal.status = if (reAddGoal.targetDate.isNullOrEmpty()) GoalStatus.FUTURE else GoalStatus.ACTIVE
+    return service.updateGoalStatus(goalUuid, reAddGoal)
   }
 
   @PatchMapping("/{goalUuid}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/data/Goal.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/data/Goal.kt
@@ -7,7 +7,7 @@ data class Goal(
   val areaOfNeed: String? = null,
   val targetDate: String? = null,
   val relatedAreasOfNeed: List<String> = emptyList(),
-  val status: GoalStatus? = null,
+  var status: GoalStatus? = null,
   val note: String? = null,
   val steps: List<Step> = emptyList(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/data/ReAddGoal.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/data/ReAddGoal.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.sentenceplan.data
+
+data class ReAddGoal(
+  val note: String,
+  val targetDate: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
@@ -193,8 +193,7 @@ class GoalService(
     // 1. if we have a note value, create a new note of the correct type
     // 2. update the current goal status
 
-    val requiredFields = listOf(updatedGoal.status, updatedGoal.note)
-    if (requiredFields.any { it == null }) {
+    if (updatedGoal.status == null || (updatedGoal.status == GoalStatus.REMOVED && updatedGoal.note.isNullOrEmpty())) {
       throw ValidationException("One or more required fields are null")
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/GoalService.kt
@@ -201,7 +201,7 @@ class GoalService(
     val goalEntity = goalRepository.getGoalByUuid(goalUuid)
 
     // TODO this needs changing to remove the first two lines of the `when` so that we only expect a status
-    // when the goal is being removed or achieved; otherwise the new goal status should be calculated from the targetDate.
+    // when the goal is being removed or achieved; otherwise the goal's new status should be calculated from the targetDate.
 
     // If the existing goal status is REMOVED and the new status adds it back to plan, mark the note as READDED
     val goalNoteEntity = GoalNoteEntity(note = updatedGoal.note!!, goal = goalEntity).apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
@@ -282,7 +282,7 @@ class GoalControllerTest : IntegrationTestBase() {
   }
 
   @Nested
-  @DisplayName("deleteTests")
+  @DisplayName("deleteGoal")
   @Sql(scripts = [ "/db/test/plan_data.sql", "/db/test/goals_data.sql", "/db/test/step_data.sql" ], executionPhase = BEFORE_TEST_CLASS)
   @Sql(scripts = [ "/db/test/step_cleanup.sql", "/db/test/goals_cleanup.sql", "/db/test/plan_cleanup.sql" ], executionPhase = AFTER_TEST_CLASS)
   inner class GoalControllerDeleteTests {
@@ -590,7 +590,48 @@ class GoalControllerTest : IntegrationTestBase() {
   @DisplayName("removeGoal")
   @Sql(scripts = [ "/db/test/plan_data.sql", "/db/test/goals_data.sql", "/db/test/related_area_of_need_data.sql" ], executionPhase = BEFORE_TEST_CLASS)
   @Sql(scripts = [ "/db/test/related_area_of_need_cleanup.sql", "/db/test/goals_cleanup.sql", "/db/test/plan_cleanup.sql" ], executionPhase = AFTER_TEST_CLASS)
-  open inner class RemoveGoalTests
+  open inner class RemoveGoalTests {
+    @Test
+    @Transactional
+    open fun `remove goal with a note`() {
+      val goalUuid = "31d7e986-4078-4f5c-af1d-115f9ba3722d"
+      val note = Goal(note = "Removing note")
+
+      // If you goalRepository.findByUuid() here, the test will fail.
+
+      webTestClient.post().uri("/goals/$goalUuid/remove").header("Content-Type", "application/json")
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_SENTENCE_PLAN_READ", "ROLE_SENTENCE_PLAN_WRITE")))
+        .bodyValue(note)
+        .exchange()
+        .expectStatus().isOk
+
+      val goal = goalRepository.getGoalByUuid(UUID.fromString(goalUuid))
+      assertThat(goal.status).isEqualTo(GoalStatus.REMOVED)
+      assertThat(goal.relatedAreasOfNeed).isNotEmpty()
+      assertThat(goal.notes.first().note).isEqualTo("Removing note")
+      assertThat(goal.notes.first().type).isEqualTo(GoalNoteType.REMOVED)
+    }
+
+    @Test
+    @Transactional
+    open fun `remove goal without a note should fail`() {
+      val goalUuid = "31d7e986-4078-4f5c-af1d-115f9ba3722d"
+      val note = Goal(note = "")
+
+      // If you goalRepository.findByUuid() here, the test will fail.
+
+      webTestClient.post().uri("/goals/$goalUuid/remove").header("Content-Type", "application/json")
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_SENTENCE_PLAN_READ", "ROLE_SENTENCE_PLAN_WRITE")))
+        .bodyValue(note)
+        .exchange()
+        .expectStatus().is4xxClientError
+
+      val goal = goalRepository.getGoalByUuid(UUID.fromString(goalUuid))
+      assertThat(goal.status).isEqualTo(GoalStatus.ACTIVE)
+      assertThat(goal.relatedAreasOfNeed).isNotEmpty()
+      assertThat(goal.notes.size).isEqualTo(0)
+    }
+  }
 
   @Nested
   @DisplayName("reAddGoal")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
@@ -539,6 +539,66 @@ class GoalControllerTest : IntegrationTestBase() {
   }
 
   @Nested
+  @DisplayName("achieveGoal")
+  @Sql(scripts = [ "/db/test/plan_data.sql", "/db/test/goals_data.sql", "/db/test/related_area_of_need_data.sql" ], executionPhase = BEFORE_TEST_CLASS)
+  @Sql(scripts = [ "/db/test/related_area_of_need_cleanup.sql", "/db/test/goals_cleanup.sql", "/db/test/plan_cleanup.sql" ], executionPhase = AFTER_TEST_CLASS)
+  open inner class AchieveGoalTests {
+    @Test
+    @Transactional
+    open fun `achieve goal without a note`() {
+      val goalUuid = "31d7e986-4078-4f5c-af1d-115f9ba3722d"
+      val note = Goal(note = "")
+
+      // If you goalRepository.findByUuid() here, the test will fail.
+
+      webTestClient.post().uri("/goals/$goalUuid/achieve").header("Content-Type", "application/json")
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_SENTENCE_PLAN_READ", "ROLE_SENTENCE_PLAN_WRITE")))
+        .bodyValue(note)
+        .exchange()
+        .expectStatus().isOk
+
+      val goal = goalRepository.getGoalByUuid(UUID.fromString(goalUuid))
+      assertThat(goal.status).isEqualTo(GoalStatus.ACHIEVED)
+      assertThat(goal.relatedAreasOfNeed).isNotEmpty()
+      assertThat(goal.notes.first().note).isEqualTo("")
+      assertThat(goal.notes.first().type).isEqualTo(GoalNoteType.ACHIEVED)
+    }
+
+    @Test
+    @Transactional
+    open fun `achieve goal with a note and related areas of need are preserved`() {
+      val note = Goal(note = "A note")
+      val goalUuid = "31d7e986-4078-4f5c-af1d-115f9ba3722d"
+
+      // If you goalRepository.findByUuid() here, the test will fail.
+
+      webTestClient.post().uri("/goals/$goalUuid/achieve").header("Content-Type", "application/json")
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_SENTENCE_PLAN_READ", "ROLE_SENTENCE_PLAN_WRITE")))
+        .bodyValue(note)
+        .exchange()
+        .expectStatus().isOk
+
+      val goal = goalRepository.getGoalByUuid(UUID.fromString(goalUuid))
+      assertThat(goal.status).isEqualTo(GoalStatus.ACHIEVED)
+      assertThat(goal.relatedAreasOfNeed).isNotEmpty()
+      assertThat(goal.notes.first().note).isEqualTo("A note")
+      assertThat(goal.notes.first().type).isEqualTo(GoalNoteType.ACHIEVED)
+    }
+  }
+
+  @Nested
+  @DisplayName("removeGoal")
+  @Sql(scripts = [ "/db/test/plan_data.sql", "/db/test/goals_data.sql", "/db/test/related_area_of_need_data.sql" ], executionPhase = BEFORE_TEST_CLASS)
+  @Sql(scripts = [ "/db/test/related_area_of_need_cleanup.sql", "/db/test/goals_cleanup.sql", "/db/test/plan_cleanup.sql" ], executionPhase = AFTER_TEST_CLASS)
+  open inner class RemoveGoalTests
+
+  @Nested
+  @DisplayName("reAddGoal")
+  @Sql(scripts = [ "/db/test/plan_data.sql", "/db/test/goals_data.sql", "/db/test/related_area_of_need_data.sql" ], executionPhase = BEFORE_TEST_CLASS)
+  @Sql(scripts = [ "/db/test/related_area_of_need_cleanup.sql", "/db/test/goals_cleanup.sql", "/db/test/plan_cleanup.sql" ], executionPhase = AFTER_TEST_CLASS)
+  open inner class ReaddGoalTests
+
+  @Nested
   @DisplayName("updateGoal")
   @Sql(scripts = [ "/db/test/plan_data.sql", "/db/test/goals_data.sql", "/db/test/related_area_of_need_data.sql" ], executionPhase = BEFORE_TEST_CLASS)
   @Sql(scripts = [ "/db/test/related_area_of_need_cleanup.sql", "/db/test/goals_cleanup.sql", "/db/test/plan_cleanup.sql" ], executionPhase = AFTER_TEST_CLASS)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalStatus
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.StepStatus
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 private const val TEST_DATA_GOAL_UUID = "31d7e986-4078-4f5c-af1d-115f9ba3722d"
@@ -635,9 +636,75 @@ class GoalControllerTest : IntegrationTestBase() {
 
   @Nested
   @DisplayName("reAddGoal")
-  @Sql(scripts = [ "/db/test/plan_data.sql", "/db/test/goals_data.sql", "/db/test/related_area_of_need_data.sql" ], executionPhase = BEFORE_TEST_CLASS)
-  @Sql(scripts = [ "/db/test/related_area_of_need_cleanup.sql", "/db/test/goals_cleanup.sql", "/db/test/plan_cleanup.sql" ], executionPhase = AFTER_TEST_CLASS)
-  open inner class ReaddGoalTests
+  @Sql(scripts = [ "/db/test/plan_data.sql", "/db/test/goals_data.sql", "/db/test/related_area_of_need_data.sql", "/db/test/goal_removed.sql" ], executionPhase = BEFORE_TEST_METHOD)
+  @Sql(scripts = [ "/db/test/related_area_of_need_cleanup.sql", "/db/test/goals_cleanup.sql", "/db/test/plan_cleanup.sql" ], executionPhase = AFTER_TEST_METHOD)
+  open inner class ReaddGoalTests {
+
+    @Test
+    open fun `re-add goal with a note and no target date`() {
+      val goalUuid = "31d7e986-4078-4f5c-af1d-115f9ba3722d"
+      val note = Goal(note = "Re-adding note")
+
+      // If you goalRepository.findByUuid() here, the test will fail.
+
+      webTestClient.post().uri("/goals/$goalUuid/readd").header("Content-Type", "application/json")
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_SENTENCE_PLAN_READ", "ROLE_SENTENCE_PLAN_WRITE")))
+        .bodyValue(note)
+        .exchange()
+        .expectStatus().isOk
+
+//      val goal = goalRepository.getGoalByUuid(UUID.fromString(goalUuid))
+//      assertThat(goal.status).isEqualTo(GoalStatus.FUTURE)
+//      assertThat(goal.relatedAreasOfNeed).isNotEmpty()
+//      assertThat(goal.notes.first().note).isEqualTo("Re-adding note")
+//      assertThat(goal.notes.first().type).isEqualTo(GoalNoteType.READDED)
+    }
+
+    //    @Sql(scripts = ["/db/test/goal_removed.sql"], executionPhase = BEFORE_TEST_METHOD)
+    @Test
+    fun `re-add goal with a note and a target date`() {
+      val goalUuid = "778b8e52-5927-42d4-9c05-7029ef3c6f6d" // goal for the future
+      val reAddGoal = Goal(note = "Re-adding note", targetDate = LocalDate.now().plusWeeks(20).format(DateTimeFormatter.ISO_LOCAL_DATE))
+
+      // If you goalRepository.findByUuid() here, the test will fail.
+
+      webTestClient.post().uri("/goals/$goalUuid/readd").header("Content-Type", "application/json")
+        .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_SENTENCE_PLAN_READ", "ROLE_SENTENCE_PLAN_WRITE")))
+        .bodyValue(reAddGoal)
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<GoalEntity>()
+        .consumeWith { response ->
+          val goal = response.responseBody
+          assertThat(goal?.status).isEqualTo(GoalStatus.ACTIVE)
+          assertThat(goal?.targetDate).isEqualTo(LocalDate.now().plusWeeks(20))
+          assertThat(goal?.relatedAreasOfNeed).isEmpty()
+          assertThat(goal?.notes?.first()?.note).isEqualTo("Re-adding note")
+          assertThat(goal?.notes?.first()?.type).isEqualTo(GoalNoteType.READDED)
+        }
+    }
+
+    /** currently unsupported in GoalService
+     @Test
+     @Transactional
+     open fun `re-add goal without a note should fail`() {
+     val goalUuid = "31d7e986-4078-4f5c-af1d-115f9ba3722d"
+     val note = Goal(note = "")
+
+     // If you goalRepository.findByUuid() here, the test will fail.
+
+     webTestClient.post().uri("/goals/$goalUuid/readd").header("Content-Type", "application/json")
+     .headers(setAuthorisation(user = authenticatedUser, roles = listOf("ROLE_SENTENCE_PLAN_READ", "ROLE_SENTENCE_PLAN_WRITE")))
+     .bodyValue(note)
+     .exchange()
+     .expectStatus().is4xxClientError
+
+     val goal = goalRepository.getGoalByUuid(UUID.fromString(goalUuid))
+     assertThat(goal.status).isEqualTo(GoalStatus.ACTIVE)
+     assertThat(goal.relatedAreasOfNeed).isNotEmpty()
+     assertThat(goal.notes.size).isEqualTo(0)
+     }*/
+  }
 
   @Nested
   @DisplayName("updateGoal")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/integration/GoalControllerTest.kt
@@ -652,15 +652,16 @@ class GoalControllerTest : IntegrationTestBase() {
         .bodyValue(note)
         .exchange()
         .expectStatus().isOk
-
-//      val goal = goalRepository.getGoalByUuid(UUID.fromString(goalUuid))
-//      assertThat(goal.status).isEqualTo(GoalStatus.FUTURE)
-//      assertThat(goal.relatedAreasOfNeed).isNotEmpty()
-//      assertThat(goal.notes.first().note).isEqualTo("Re-adding note")
-//      assertThat(goal.notes.first().type).isEqualTo(GoalNoteType.READDED)
+        .expectBody<GoalEntity>()
+        .consumeWith { response ->
+          val goal = response.responseBody
+          assertThat(goal.status).isEqualTo(GoalStatus.FUTURE)
+          assertThat(goal.relatedAreasOfNeed).isNotEmpty()
+          assertThat(goal.notes.first().note).isEqualTo("Re-adding note")
+          assertThat(goal.notes.first().type).isEqualTo(GoalNoteType.READDED)
+        }
     }
 
-    //    @Sql(scripts = ["/db/test/goal_removed.sql"], executionPhase = BEFORE_TEST_METHOD)
     @Test
     fun `re-add goal with a note and a target date`() {
       val goalUuid = "778b8e52-5927-42d4-9c05-7029ef3c6f6d" // goal for the future

--- a/src/test/resources/db/test/goal_removed.sql
+++ b/src/test/resources/db/test/goal_removed.sql
@@ -1,0 +1,2 @@
+-- set goal status to REMOVED for all goals so different states can be tested
+UPDATE goal SET goal_status = 'REMOVED';


### PR DESCRIPTION
This PR is the first phase of refactoring the updateGoalStatus function.

It adds in the new endpoints agreed in SP2-1526 but just calls to the existing updateGoalStatus function. It doesn't remove any endpoints.

The next step will be to change the UI application to use these new endpoints, followed by a refactoring in this repo which replaces the updateGoalStatus function with three functions, one for each of the new endpoints.

This is to keep the list of changes low and to lower the immediate deployment dependency concerns between the two applications.