### PR TITLE
Updates uk.gov.justice.hmpps.gradle-spring-boot to 7.1.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.springframework.boot.gradle.tasks.run.BootRun
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "7.1.2"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "7.1.4"
   kotlin("plugin.spring") version "2.1.10"
   kotlin("plugin.jpa") version "2.1.10"
   id("org.openapi.generator") version "7.11.0"


### PR DESCRIPTION
This resolves a MEDIUM CVE. OWASP run is here: https://github.com/ministryofjustice/hmpps-sentence-plan/actions/runs/13810513964