### PR TITLE
SP2-1394 Adds handling wiremock requests for ndelius information

### DIFF
--- a/wiremock/mappings/oauth2.json
+++ b/wiremock/mappings/oauth2.json
@@ -1,0 +1,23 @@
+{
+    "request": {
+    "method": "POST",
+        "url": "/oauth/token",
+        "headers": {
+        "Content-Type": {
+            "equalTo": "application/x-www-form-urlencoded"
+        }
+    },
+    "bodyPatterns": [
+        {
+            "matches": ".*client_id=your-client-id.*client_secret=your-client-secret.*"
+        }
+    ]
+},
+    "response": {
+    "status": 200,
+        "headers": {
+        "Content-Type": "application/json"
+    },
+    "body": "{\"access_token\":\"mocked-oauth-token\",\"token_type\":\"Bearer\",\"expires_in\":3600}"
+}
+}


### PR DESCRIPTION
The `ARNSApiService.deliusRestClient` performs OAuth2 negotiation when talking to its endpoint. In the case where the endpoint is wiremock the negotiation was failing, which in turn made the tests which use the wiremock endpoint to fail.

This PR should allow the negotiation to succeed.