### PR TITLE
ACE-277: Added associate endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/PlanController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/controller/PlanController.kt
@@ -6,6 +6,7 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -16,6 +17,7 @@ import uk.gov.justice.digital.hmpps.sentenceplan.data.Agreement
 import uk.gov.justice.digital.hmpps.sentenceplan.data.Goal
 import uk.gov.justice.digital.hmpps.sentenceplan.data.Note
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.GoalEntity
+import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.entity.PlanVersionEntity
 import uk.gov.justice.digital.hmpps.sentenceplan.exceptions.ConflictException
 import uk.gov.justice.digital.hmpps.sentenceplan.exceptions.NotFoundException
@@ -102,6 +104,20 @@ class PlanController(
       throw ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, e.message)
     } catch (e: ConflictException) {
       throw ResponseStatusException(HttpStatus.CONFLICT, e.message)
+    }
+  }
+
+  @PutMapping("associate/{planUuid}/{crn}")
+  @PreAuthorize("hasAnyRole('ROLE_SENTENCE_PLAN_WRITE')")
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  fun associateCrnWithPlan(
+    @PathVariable planUuid: UUID,
+    @PathVariable crn: String,
+  ): PlanEntity {
+    try {
+      return planService.associate(planUuid, crn)
+    } catch (e: NotFoundException) {
+      throw ResponseStatusException(HttpStatus.NOT_FOUND, e.message)
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/entity/PlanEntity.kt
@@ -131,6 +131,9 @@ class PlanEntity(
   @OneToOne()
   @JoinColumn(name = "current_plan_version_id")
   var currentVersion: PlanVersionEntity? = null,
+
+  @Column(name = "person_crn")
+  var crn: String? = null,
 )
 
 enum class PublishState {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/sentenceplan/services/PlanService.kt
@@ -266,4 +266,16 @@ class PlanService(
       throw NotFoundException("Plan not found for id $planUuid")
     }
   }
+
+  @Transactional
+  fun associate(planUuid: UUID, crn: String): PlanEntity {
+    val planEntity = planRepository.getByUuid(planUuid)
+
+    if (planEntity.crn.isNullOrEmpty()) {
+      planEntity.crn = crn
+      planRepository.save(planEntity)
+    }
+
+    return planEntity
+  }
 }

--- a/src/main/resources/db/migration/V19__added_person_id_fields.sql
+++ b/src/main/resources/db/migration/V19__added_person_id_fields.sql
@@ -1,0 +1,2 @@
+ALTER TABLE plan
+    ADD COLUMN IF NOT EXISTS person_crn varchar NULL;


### PR DESCRIPTION
Adds `associate` endpoint which adds a persons CRN into the `Plan` table to associate that plan with them. It does this by using the HandoverContext in SP UI and passing the Plan UUID and persons CRN through to the endpoint. If the Plan already contains a CRN then we do not save it again as it has already been associated with a person.

This is called by https://github.com/ministryofjustice/hmpps-sentence-plan-ui/pull/481